### PR TITLE
DoctorReid#181 修复低帧率下可能无法交任务的问题

### DIFF
--- a/config/key_sim/真拿命验收.sample.yml
+++ b/config/key_sim/真拿命验收.sample.yml
@@ -20,8 +20,8 @@ operations:
     way: "按下"
     press: 3
 
-  # 到尽头后 先等待0.1秒
-    post_delay: 0.1
+  # 到尽头后 先等待0.2秒
+    post_delay: 0.2
   # 用闪避后退触发交互
   - op_name: "按键-闪避"
     post_delay: 0.5

--- a/config/key_sim/真拿命验收.sample.yml
+++ b/config/key_sim/真拿命验收.sample.yml
@@ -21,7 +21,12 @@ operations:
     press: 3
 
   # 到尽头后 先等待0.2秒
-    post_delay: 0.2
+  - op_name: "按键-移动-右"
+    way: "松开"
+    post_delay: 0.1
+  - op_name: "按键-移动-前"
+    way: "松开"
+    post_delay: 0.1
   # 用闪避后退触发交互
   - op_name: "按键-闪避"
     post_delay: 0.5

--- a/config/key_sim/真拿命验收.sample.yml
+++ b/config/key_sim/真拿命验收.sample.yml
@@ -20,6 +20,8 @@ operations:
     way: "按下"
     press: 3
 
-  # 到尽头后 用闪避后退触发交互
+  # 到尽头后 先等待0.1秒
+    post_delay: 0.1
+  # 用闪避后退触发交互
   - op_name: "按键-闪避"
     post_delay: 0.5


### PR DESCRIPTION
我已经定位了这个问题，它发生的原因可能不是偏离，而是低帧率下（譬如帧率设为30）不能稳定按出闪避，所以看起来像偏了。比利到墙边后等待一段时间再按闪避即可解决。