### PR TITLE
“模板生成”错误修复

### DIFF
--- a/config/auto_battle_state_handler/站场模板-艾莲.sample.yml
+++ b/config/auto_battle_state_handler/站场模板-艾莲.sample.yml
@@ -5,21 +5,17 @@ handlers:
     - states: "([按键-连携技-左, 0, 12] | [按键-连携技-右, 0, 12]) & [按键可用-终结技]"
       operations:
         - op_name: "按键-闪避"
-          data: []
         - op_name: "等待秒数"
-          data: [ "0.1" ]
+          post_delay: 0.1
         - op_name: "按键-终结技"
-          data: []
         - op_name: "等待秒数"
-          data: [ "2.5" ]
+          post_delay: 2.5
 
     # 失衡阶段 EA 2连
     - states: "([按键-连携技-左, 0, 12] | [按键-连携技-右, 0, 12]) & [按键可用-特殊攻击]"
       operations:
         - op_name: "按键-闪避"
-          data: []
-        - op_name: "等待秒数"
-          data: [ "0.1" ]
+          post_delay: 0.1
         - operation_template: "艾莲-EA连击"
         - operation_template: "艾莲-EA连击"
 

--- a/src/zzz_od/action_recorder/template_generator.py
+++ b/src/zzz_od/action_recorder/template_generator.py
@@ -1,16 +1,12 @@
 import pickle
 import os
 from copy import deepcopy
-from multiprocessing.util import is_exiting
-
 import yaml
 
 import numpy as np
 
 from sklearn.cluster import KMeans
 from sklearn.metrics import euclidean_distances
-
-from gensim.models import Word2Vec as GSWord2Vec
 
 from one_dragon.utils import os_utils
 from one_dragon.utils.log_utils import log
@@ -449,6 +445,7 @@ class SelfAdaptiveGenerator:
         return agent_sentences, agent_comb_sentences
 
     def _word2vec(self, agent_comb_sentences: dict):
+        from gensim.models import Word2Vec as GSWord2Vec
         # 无监督训练获取分词向量
         agent_models = {}
         for agent in self.agent_names:

--- a/src/zzz_od/action_recorder/template_generator.py
+++ b/src/zzz_od/action_recorder/template_generator.py
@@ -869,7 +869,11 @@ class SelfAdaptiveGenerator:
 
     def _get_existing_template(self):
         existing_agent_handlers = get_all_auto_battle_op("auto_battle_state_handler")  # 获取既有模板
-        existing_agent_handler_names = [handler.module_name.split('-')[-1] for handler in existing_agent_handlers]
+
+        existing_agent_handlers = [handler
+                                   for handler in existing_agent_handlers if '站场模板' in handler.module_name]  # 只筛选站场模板, 其他不需要
+        existing_agent_handler_names = [handler.module_name.split('-')[-1]
+                                        for handler in existing_agent_handlers if '站场模板' in handler.module_name]
 
         handlers = {}
         is_template_existed = {}

--- a/src/zzz_od/action_recorder/template_generator.py
+++ b/src/zzz_od/action_recorder/template_generator.py
@@ -77,17 +77,21 @@ class ImportantOperation(Enum):
 class PreProcessor:
     def __init__(self):
         # 直接读取log中保存的信息
-        keyboard_action_file_path = os.path.join(os_utils.get_path_under_work_dir('.log'), 'keyboard_actions.pkl')
-        with open(keyboard_action_file_path, 'rb') as file:  # 使用 'rb' 模式读取二进制文件
-            self.keyboard_flows = pickle.load(file)
+        try:
+            keyboard_action_file_path = os.path.join(os_utils.get_path_under_work_dir('.log'), 'keyboard_actions.pkl')
+            with open(keyboard_action_file_path, 'rb') as file:  # 使用 'rb' 模式读取二进制文件
+                self.keyboard_flows = pickle.load(file)
 
-        mouse_action_file_path = os.path.join(os_utils.get_path_under_work_dir('.log'), 'mouse_actions.pkl')
-        with open(mouse_action_file_path, 'rb') as file:  # 使用 'rb' 模式读取二进制文件
-            self.mouse_flows = pickle.load(file)
+            mouse_action_file_path = os.path.join(os_utils.get_path_under_work_dir('.log'), 'mouse_actions.pkl')
+            with open(mouse_action_file_path, 'rb') as file:  # 使用 'rb' 模式读取二进制文件
+                self.mouse_flows = pickle.load(file)
 
-        status_file_path = os.path.join(os_utils.get_path_under_work_dir('.log'), 'status.pkl')
-        with open(status_file_path, 'rb') as file:  # 使用 'rb' 模式读取二进制文件
-            self.status_flows = pickle.load(file)
+            status_file_path = os.path.join(os_utils.get_path_under_work_dir('.log'), 'status.pkl')
+            with open(status_file_path, 'rb') as file:  # 使用 'rb' 模式读取二进制文件
+                self.status_flows = pickle.load(file)
+
+        except FileNotFoundError:
+            raise FileNotFoundError("动作和状态还未录制, 请先录制...")
 
         for index in range(len(self.status_flows)):
             agent_info = self.status_flows[index][1]['代理人顺序']

--- a/src/zzz_od/gui/view/battle_assistant/template_generation_interface.py
+++ b/src/zzz_od/gui/view/battle_assistant/template_generation_interface.py
@@ -147,21 +147,16 @@ class TemplateGenerationInterface(AppRunInterface):
         根据记录生成模板
         :return:
         """
-        try:
-            pp = PreProcessor()  # 预处理
-            merged_status_ops = pp.pre_process()
+        pp = PreProcessor()  # 预处理
+        merged_status_ops = pp.pre_process()
 
-            sag = SelfAdaptiveGenerator(merged_status_ops, pp.agent_names,
-                                        self._use_existing_tpl, self.add_switch_opt)  # 模板生成
-            agent_templates, special_status = sag.get_templates()
-            sag.output_yaml(agent_templates, special_status)
+        sag = SelfAdaptiveGenerator(merged_status_ops, pp.agent_names,
+                                    self._use_existing_tpl, self.add_switch_opt)  # 模板生成
+        agent_templates, special_status = sag.get_templates()
+        sag.output_yaml(agent_templates, special_status)
 
-            msg = '模板生成成功, 请在.log文件夹内查看'
-            log.info(msg)
-        except Exception as e:
-            msg = '动作-状态记录未录制或存在格式错误'
-            log.info(msg)
-            log.info(e)
+        msg = '模板生成成功, 请在.log文件夹内查看'
+        log.info(msg)
 
     def _on_key_press(self, event: ContextEventItem) -> None:
         """


### PR DESCRIPTION
#219 
发现4处错误，已经修复：
1. 缓冲区最后记录未保存，已修复；
2. 角色数据缺失异常处理(至少要保证所有代理人都至少上过一次场且有所动作)；
3. 样本较少时特殊处理；
4. 单个代理人可能有多个模板，只读取站场模板

目前“定期清剿”、“实战模拟室”和“专业挑战室”都测试过，暂时没发现新问题

后续各代理人的站场模板会根据既有配队模板进行优化，有一些确实是太旧了