### PR TITLE
#280 添加剪贴板输入账号密码的选项，避免中文输入法导致的切换失败

### DIFF
--- a/src/one_dragon/base/controller/pc_clipboard.py
+++ b/src/one_dragon/base/controller/pc_clipboard.py
@@ -1,0 +1,85 @@
+import time
+
+import win32clipboard
+import win32con
+import pywintypes
+from pynput.keyboard import Controller, Key
+from one_dragon.utils.log_utils import log, mask_text
+
+
+class PcClipboard:
+
+    @staticmethod
+    def copy_and_paste(text: str) -> None:
+        """
+        将给定的文本复制到剪贴板，然后再从剪贴板粘贴出来。
+
+        :param text: 要复制到剪贴板的文本
+        :return: 无
+        """
+        PcClipboard.copy_string(text)
+        PcClipboard.paste_text()
+        PcClipboard.empty_clipboard()
+
+    @staticmethod
+    def empty_clipboard() -> None:
+        """
+        清空剪贴板的内容。
+
+        :return: 无
+        """
+        try:
+            win32clipboard.OpenClipboard()
+            win32clipboard.EmptyClipboard()
+        finally:
+            win32clipboard.CloseClipboard()
+
+    @staticmethod
+    def copy_string(text: str) -> None:
+        """
+        将给定的文本复制到剪贴板。
+
+        :param text: 要复制到剪贴板的文本
+        :return: 无
+        """
+        try:
+            # 脱敏（前后10%的字符不加密）
+            log.info(f'复制文字到剪切板:{mask_text(text)}')
+            win32clipboard.OpenClipboard()
+            win32clipboard.EmptyClipboard()
+            win32clipboard.SetClipboardText(text, win32con.CF_UNICODETEXT)
+            log.info('复制文字到剪切板成功')
+        finally:
+            win32clipboard.CloseClipboard()
+
+    @staticmethod
+    def paste_text() -> str:
+        """
+        从剪贴板粘贴文本，并模拟按下 Ctrl+V 组合键。
+
+        :return: 从剪贴板获取的文本，如果获取失败则返回空字符串
+        """
+        keyboard = Controller()
+
+        try:
+            log.info('粘贴文字, 查找剪切板')
+            win32clipboard.OpenClipboard()
+            data = win32clipboard.GetClipboardData(win32con.CF_UNICODETEXT)
+            log.info(f'粘贴文字, 获取到:{mask_text(data)}')
+        except pywintypes.error:
+            data = ''
+        finally:
+            win32clipboard.CloseClipboard()
+
+        # 使用 pynput 模拟粘贴操作
+        log.info('粘贴文字, 按下 Ctrl+V')
+        log.debug('粘贴文字, 按下 Ctrl')
+        with keyboard.pressed(Key.ctrl):
+            time.sleep(0.2)
+            log.debug('粘贴文字, 按下 V')
+            keyboard.press('v')
+            time.sleep(0.2)
+            log.debug('粘贴文字, 释放 V')
+            keyboard.release('v')
+
+        return data

--- a/src/one_dragon/utils/log_utils.py
+++ b/src/one_dragon/utils/log_utils.py
@@ -37,4 +37,18 @@ def set_log_level(level: int) -> None:
         handler.setLevel(level)
 
 
+def mask_text(text: str) -> str:
+    """
+    对给定的文本进行脱敏处理，保留首尾部分字符，其余用 * 替换。
+    如果字符数少于5个，则只保留首字符不脱敏。
+
+    :param text: 需要脱敏的文本
+    :return: 脱敏后的文本
+    """
+    if len(text) < 5:
+        return text[0] + '*' * (len(text) - 1)
+    else:
+        return text[:2] + '*' * (len(text) - 4) + text[-2:]
+
+
 log = get_logger()

--- a/src/zzz_od/config/game_config.py
+++ b/src/zzz_od/config/game_config.py
@@ -76,6 +76,14 @@ class GameConfig(YamlConfig):
         self.update('password', new_value)
 
     @property
+    def enter_clipboard(self) -> bool:
+        return self.get('enter_clipboard', False)
+
+    @enter_clipboard.setter
+    def enter_clipboard(self, new_value: bool) -> None:
+        self.update('enter_clipboard', new_value)
+
+    @property
     def game_region(self) -> str:
         return self.get('game_region', GameRegionEnum.CN.value.value)
 

--- a/src/zzz_od/gui/view/setting/setting_game_interface.py
+++ b/src/zzz_od/gui/view/setting/setting_game_interface.py
@@ -9,6 +9,7 @@ from one_dragon.gui.component.column_widget import ColumnWidget
 from one_dragon.gui.component.interface.vertical_scroll_interface import VerticalScrollInterface
 from one_dragon.gui.component.setting_card.combo_box_setting_card import ComboBoxSettingCard
 from one_dragon.gui.component.setting_card.key_setting_card import KeySettingCard
+from one_dragon.gui.component.setting_card.switch_setting_card import SwitchSettingCard
 from one_dragon.gui.component.setting_card.text_setting_card import TextSettingCard
 from one_dragon.utils.i18_utils import gt
 from one_dragon.utils.log_utils import log
@@ -55,6 +56,12 @@ class SettingGameInterface(VerticalScrollInterface):
         self.game_password_opt = TextSettingCard(icon=FluentIcon.EXPRESSIVE_INPUT_ENTRY, title='密码',
                                                  content='放心不会盗你的号 异地登陆需要验证')
         basic_group.addSettingCard(self.game_password_opt)
+
+        self.game_enter_clipboard_opt = SwitchSettingCard(
+            icon=FluentIcon.CODE, title='启用剪切板输入',
+            content='启用剪切板输入账号密码，能避免中文输入法导致的切换账号失败，但会造成密码泄露风险（虽然在输入后会自动清空，但仍有被其他软件截取的风险）'
+        )
+        basic_group.addSettingCard(self.game_enter_clipboard_opt)
 
         return basic_group
 
@@ -274,6 +281,7 @@ class SettingGameInterface(VerticalScrollInterface):
         self.game_region_opt.value_changed.disconnect(self._on_game_region_changed)
         self.game_account_opt.value_changed.disconnect(self._on_game_account_changed)
         self.game_password_opt.value_changed.disconnect(self._on_game_password_changed)
+        self.game_enter_clipboard_opt.value_changed.disconnect(self._on_game_enter_clipboard_changed)
 
         game_region = get_config_item_from_enum(GameRegionEnum, self.ctx.game_config.game_region)
         if game_region is not None:
@@ -281,6 +289,7 @@ class SettingGameInterface(VerticalScrollInterface):
         self.game_path_opt.setContent(self.ctx.game_config.game_path)
         self.game_account_opt.setValue(self.ctx.game_config.account)
         self.game_password_opt.setValue(self.ctx.game_config.password)
+        self.game_enter_clipboard_opt.setValue(self.ctx.game_config.enter_clipboard)
 
         self.key_normal_attack_opt.setValue(self.ctx.game_config.key_normal_attack)
         self.key_dodge_opt.setValue(self.ctx.game_config.key_dodge)
@@ -303,6 +312,7 @@ class SettingGameInterface(VerticalScrollInterface):
         self.game_region_opt.value_changed.connect(self._on_game_region_changed)
         self.game_account_opt.value_changed.connect(self._on_game_account_changed)
         self.game_password_opt.value_changed.connect(self._on_game_password_changed)
+        self.game_enter_clipboard_opt.value_changed.connect(self._on_game_enter_clipboard_changed)
 
     def _update_gamepad_part(self) -> None:
         """
@@ -402,6 +412,9 @@ class SettingGameInterface(VerticalScrollInterface):
 
     def _on_game_password_changed(self, value: str) -> None:
         self.ctx.game_config.password = value
+
+    def _on_game_enter_clipboard_changed(self, value: str) -> None:
+        self.ctx.game_config.enter_clipboard = value
 
     def _on_key_normal_attack_changed(self, key: str) -> None:
         self.ctx.game_config.key_normal_attack = key

--- a/src/zzz_od/operation/enter_game/enter_game.py
+++ b/src/zzz_od/operation/enter_game/enter_game.py
@@ -1,6 +1,7 @@
 import time
 
 from one_dragon.base.config.one_dragon_config import InstanceRun
+from one_dragon.base.controller.pc_clipboard import PcClipboard
 from one_dragon.base.operation.operation_edge import node_from
 from one_dragon.base.operation.operation_node import operation_node
 from one_dragon.base.operation.operation_round_result import OperationRoundResult
@@ -57,14 +58,22 @@ class EnterGame(ZOperation):
         if self.ctx.game_config.account == '' or self.ctx.game_config.password == '':
             return self.round_fail('未配置账号密码')
 
+        use_clipboard = self.ctx.game_config.enter_clipboard
+
         self.round_by_click_area('打开游戏', '账号输入区域')
         time.sleep(0.5)
-        self.ctx.controller.keyboard_controller.keyboard.type(self.ctx.game_config.account)
+        if use_clipboard:
+            PcClipboard.copy_and_paste(self.ctx.game_config.account)
+        else:
+            self.ctx.controller.keyboard_controller.keyboard.type(self.ctx.game_config.account)
         time.sleep(1.5)
 
         self.round_by_click_area('打开游戏', '密码输入区域')
         time.sleep(0.5)
-        self.ctx.controller.keyboard_controller.keyboard.type(self.ctx.game_config.password)
+        if use_clipboard:
+            PcClipboard.copy_and_paste(self.ctx.game_config.password)
+        else:
+            self.ctx.controller.keyboard_controller.keyboard.type(self.ctx.game_config.password)
         time.sleep(1.5)
 
         self.round_by_click_area('打开游戏', '同意按钮')


### PR DESCRIPTION
添加可选项：剪贴板输入账号密码
![image](https://github.com/user-attachments/assets/1588fcbd-3bfc-43a0-9ebe-bfd9032719a9)
添加逻辑与日志
![image](https://github.com/user-attachments/assets/1ed8a061-bacb-4aba-a791-9fcf44b44645)
添加脱敏方法
