### PR TITLE
fix：修复

### DIFF
--- a/src/one_dragon/utils/app_utils.py
+++ b/src/one_dragon/utils/app_utils.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 
 from one_dragon.utils import os_utils, cmd_utils
 
@@ -14,7 +15,7 @@ def start_one_dragon(restart: bool):
     subprocess.Popen(f'cmd /c "start "zzz-od-runner" "{bat_path}""',
                      shell=True)
     if restart:
-        exit(0)
+        sys.exit(0)
 
 
 def restart_one_dragon():


### PR DESCRIPTION
修复启动加载name 'exit' is not definedfrom qfluentwidgets  问题

Traceback (most recent call last):
  File "one_dragon\gui\install_card\all_install_card.py", line 76, in _on_run_clicked
  File "one_dragon\utils\app_utils.py", line 17, in start_one_dragon
NameError: name 'exit' is not definedfrom qfluentwidgets 