### PR TITLE
#177 1.3前瞻兑换码修复失效日期

### DIFF
--- a/src/zzz_od/application/redemption_code/redemption_code_run_record.py
+++ b/src/zzz_od/application/redemption_code/redemption_code_run_record.py
@@ -22,7 +22,7 @@ class RedemptionCodeRunRecord(AppRunRecord):
 
         self.valid_code_list = [
             RedemptionCode('ZZZ888', '20480101'),  # 开服兑换码
-            RedemptionCode('VIRTUALREVENGE', '20241025'),  # 1.3 前瞻
+            RedemptionCode('VIRTUALREVENGE', '20241026'),  # 1.3 前瞻
         ]
 
     @property


### PR DESCRIPTION
有效期是到26号的