### PR TITLE
改善GUI卡顿

### DIFF
--- a/src/one_dragon/base/config/yaml_operator.py
+++ b/src/one_dragon/base/config/yaml_operator.py
@@ -5,6 +5,21 @@ import yaml
 
 from one_dragon.utils.log_utils import log
 
+cached_yaml_data: dict[str, tuple[float, dict]] = {}
+
+
+def read_cache_or_load(file_path: str):
+    cached = cached_yaml_data.get(file_path)
+    last_modify = os.path.getmtime(file_path)
+    if cached and cached[0] == last_modify:
+        return cached[1]
+
+    with open(file_path, 'r', encoding='utf-8') as file:
+        log.debug(f"Loaded yaml: {file_path}")
+        data = yaml.safe_load(file)
+        cached_yaml_data[file_path] = (last_modify, data)
+        return data
+
 
 class YamlOperator:
 
@@ -33,8 +48,7 @@ class YamlOperator:
             return
 
         try:
-            with open(self.file_path, 'r', encoding='utf-8') as file:
-                self.data = yaml.safe_load(file)
+            self.data = read_cache_or_load(self.file_path)
         except Exception:
             log.error(f'文件读取失败 将使用默认值 {self.file_path}', exc_info=True)
             return

--- a/src/one_dragon/base/config/yaml_operator.py
+++ b/src/one_dragon/base/config/yaml_operator.py
@@ -15,7 +15,7 @@ def read_cache_or_load(file_path: str):
         return cached[1]
 
     with open(file_path, 'r', encoding='utf-8') as file:
-        log.debug(f"Loaded yaml: {file_path}")
+        log.debug(f"加载yaml: {file_path}")
         data = yaml.safe_load(file)
         cached_yaml_data[file_path] = (last_modify, data)
         return data


### PR DESCRIPTION
目前每个plan都会读几次yaml config，比如体力计划有5个计划卡的话每张卡都会call2次get_auto_battle_op_config_list，每次切到体力计划都会再读一遍，很卡很卡，我的电脑上切到体力计划要等将近4秒。
改动是把data放在topleval的dict，检测到last_modify变动了就重新读取。
cache在toplevel我也觉得不是很好，但读yaml的地方在base class的init，有点难改，而且整个config folder也就不超1MB，所以先就这样了。

| Page   | before 1st | before 2nd | after 1st | after 2nd |
|--------|------------|------------|-----------|-----------|
| 体力计划   | 3836ms     | 1912ms     | 146ms     | 16ms      |
| 恶名狩猎计划 | 1971ms     | 1840ms     | 90ms      | 14ms      |
| 委托助手   | 364ms      | 446ms      | 4ms       | 4ms       |
| 挑战配置-迷 | 471ms      | 391ms      | 182ms     | 6ms       |
| 咖啡计划   | 397ms      | 430ms      | 41ms      | 5ms       |
| 预备编队   | 612ms      | 361ms      | 276ms     | 10ms      |
| 配置信息   | 469ms      | 353ms      | 45ms      | 4ms       |
| 指令调试   | 251ms      | 218ms      | 255ms     | 40ms      |
| 自动战斗   | 461ms      | 366ms      | 86ms      | 3ms       |
| 闪避助手   | 14ms       | 14ms       | 2ms       | 3ms       |
