### PR TITLE
fix: 为消失的战斗配置添加fallback

### DIFF
--- a/src/one_dragon/base/config/yaml_operator.py
+++ b/src/one_dragon/base/config/yaml_operator.py
@@ -107,9 +107,10 @@ class YamlOperator:
         if os.path.exists(self.file_path):
             os.remove(self.file_path)
 
+    @property
     def is_file_exists(self) -> bool:
         """
         配置文件是否存在
         :return:
         """
-        return os.path.exists(self.file_path)
+        return bool(self.file_path) and os.path.exists(self.file_path)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 自动战斗在缺少专用配置时会自动回退到“全配队通用”，不中断流程并给出告警提示。

- Bug 修复
  - 配置存在性判断更稳健，对空路径与缺失文件处理更可靠，减少异常与误报。

- 其他
  - 调整了调试场景的默认配置名称（不影响正常运行）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->