### PR TITLE
CI增加签名流程

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -211,7 +211,7 @@ jobs:
     if: ${{ (github.event_name == 'workflow_dispatch' && inputs.create_release == true) || startsWith(github.ref, 'refs/tags/') }}
     env:
       SIGNED_DIR: 'signed'
-      SIGNPATH_SIGNING_POLICY_SLUG: 'test-signing'
+      SIGNPATH_SIGNING_POLICY_SLUG: 'release-signing'
     steps:
     - name: Sign Artifact
       if: ${{ needs.build.outputs.unsigned_artifact_id != '' }}


### PR DESCRIPTION
# 主要改动

1. 上传到 signpath 签名，签名后内容会下载解压到 `deploy/dist/signed/`，文件名与原来的一致。
2. 将签名后的两个exe，复制到 `deploy/dist` 下覆盖原来的。
3. 继续原来的流程。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 构建作业公开 version/tag/unsigned_artifact_id 输出；新增签名作业与发布作业，发布流程可替换并上传已签名可执行文件；引入 RELEASE_VERSION 环境变量以在后续步骤中传递版本信息；签名与发布基于触发条件（workflow_dispatch 或 tag）有条件执行。

- **Chores**
  - 统一以构建输出驱动版本/标签和制品引用，重构变更日志与发布元数据生成，简化打包、签名与发布的资产处理与命名逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->