### PR TITLE
:sparkles: piped subprocess

### DIFF
--- a/src/one_dragon/devtools/python_launcher.py
+++ b/src/one_dragon/devtools/python_launcher.py
@@ -85,7 +85,7 @@ def create_log_folder():
     print_message(f"日志文件夹路径：{log_folder}", "PASS")
     return log_folder
 
-def execute_python_script(app_path, log_folder, no_windows: bool, args: list = None):
+def execute_python_script(app_path, log_folder, no_windows: bool, args: list = None, piped: bool = False):
     # 执行 Python 脚本并重定向输出到日志文件
     timestamp = datetime.datetime.now().strftime("%H.%M")
     log_file_path = os.path.join(log_folder, f"python_{timestamp}.log")
@@ -132,7 +132,7 @@ def execute_python_script(app_path, log_folder, no_windows: bool, args: list = N
 
 
 
-    if args and '--piped' in args and os.name == 'nt':  
+    if piped and os.name == 'nt':  
         
         # 创建Job对象
         # 用于管理进程组，解决 `taskkill /f /im OneDragon-Launcher.exe` 后Python.exe进程仍然存活的问题
@@ -194,15 +194,12 @@ def execute_python_script(app_path, log_folder, no_windows: bool, args: list = N
         # 创建进程
         # stdout, stderr 设置为 None 将会输出到当前程序相应的管道中
         
-        creationflags = subprocess.CREATE_NEW_PROCESS_GROUP
-        if no_windows:
-            creationflags |= subprocess.CREATE_NO_WINDOW
         process = subprocess.Popen(
             [uv_path] + run_args,
             stdout=None,
             stderr=None,
             stdin=None,
-            creationflags=creationflags,
+            creationflags=subprocess.CREATE_NO_WINDOW if no_windows else 0,
             text=True,
             encoding='utf-8'
         )
@@ -265,14 +262,14 @@ def execute_python_script(app_path, log_folder, no_windows: bool, args: list = N
         )
         print_message("一条龙 正在启动中，大约 3+ 秒...", "INFO")
 
-def run_python(app_path, no_windows: bool = True, args: list = None):
+def run_python(app_path, no_windows: bool = True, args: list = None, piped: bool = False):
     # 主函数
     try:
         print_message(f"当前工作目录：{path}", "INFO")
         verify_path_issues()
         configure_environment()
         log_folder = create_log_folder()
-        execute_python_script(app_path, log_folder, no_windows, args)
+        execute_python_script(app_path, log_folder, no_windows, args, piped)
     except SystemExit as e:
         print_message(f"程序已退出，状态码：{e.code}", "ERROR")
     except Exception as e:

--- a/src/one_dragon/launcher/exe_launcher.py
+++ b/src/one_dragon/launcher/exe_launcher.py
@@ -33,8 +33,6 @@ class ExeLauncher(LauncherBase):
             launch_args.append("--close-game")
         if args.shutdown:
             launch_args.extend(["--shutdown", str(args.shutdown)])
-        if args.piped:
-            launch_args.append("--piped")
         return launch_args
 
     def run_onedragon_mode(self, launch_args) -> None:

--- a/src/one_dragon/launcher/launcher_base.py
+++ b/src/one_dragon/launcher/launcher_base.py
@@ -27,7 +27,6 @@ class LauncherBase:
         parser.add_argument("-s", "--shutdown", type=int, nargs='?', const=60, help="运行后关机，可指定延迟秒数，默认60秒")
         parser.add_argument("-i", "--instance", type=str, help="指定运行的账号实例，多个用英文逗号分隔，如：1,2")
         parser.add_argument("-a", "--app", type=str, help="指定运行的应用，多个用英文逗号分隔")
-        parser.add_argument("-p", "--piped", action="store_true", help="获取该进程控制权并阻塞运行，不启动脱离的子进程，适合在脚本或其他应用中调用一条龙时配合-o使用")
 
     def run(self) -> None:
         """运行启动器"""

--- a/src/zzz_od/win_exe/launcher.py
+++ b/src/zzz_od/win_exe/launcher.py
@@ -10,7 +10,7 @@ class ZLauncher(ExeLauncher):
         ExeLauncher.__init__(self, "绝区零 一条龙 启动器", __version__)
 
     def run_onedragon_mode(self, launch_args) -> None:
-        python_launcher.run_python(["zzz_od", "application", "zzz_application_launcher.py"], no_windows=False, args=launch_args)
+        python_launcher.run_python(["zzz_od", "application", "zzz_application_launcher.py"], no_windows=False, args=launch_args, piped=True)
 
     def run_gui_mode(self) -> None:
         python_launcher.run_python(["zzz_od", "gui", "app.py"], no_windows=True)


### PR DESCRIPTION
启动器增加了 `--piped, -p` 参数， 实现进程接管，便于脚本管理一条龙的运行状态 ( 例如python， 开机脚本，其他语言 )

若增加 该参数，则会实现以下效果

### 1. 优化，命令行启动一条龙，不接收`ctrl + C`, 无法停下子进程，无法任何交互，日志乱飞。

解决之前如下

<img width="964" height="349" alt="clipboard_2025-10-10_21-16" src="https://github.com/user-attachments/assets/3aaf3785-89fc-4e9f-b912-e15bbe967970" />

优化方案：
    1). 信号传递，将 -15 等关闭信号向下透传到uv
    2). 将输入输出err重新定向到python

修改后日志不在乱飞 ctrl 也停下了任务

<img width="903" height="432" alt="image" src="https://github.com/user-attachments/assets/90013cb5-2cd3-4220-ab3b-b716ba597aaf" />


### 2. 优化，`taskkill /f /im OneDragon-Launcher.exe` (kill -9) 或 程序崩溃 时，不会同时关闭python.exe，导致子进程仍然再运行，脱离了管控，需要到任务管理器才能停止。这是UV特性 https://github.com/astral-sh/uv/issues/11817 

优化方案：使用windows的job-objects进程组管理，将子进程纳入管理

https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects

https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_basic_limit_information

当程序崩溃时，以及使用`taskkill` 可以尽量一同清理任务，防止python继续抢鼠标

<img width="441" height="126" alt="image" src="https://github.com/user-attachments/assets/ed9d52d0-cb42-4bd0-97c3-11bc373efb53" />

### 3.其他

若使用了jobObject管理进程组，想当程序运行结束时保留的进程，应当在新的进程里设置 `creationflags=subprocess.CREATE_BREAKAWAY_FROM_JOB`.  我在启动游戏里已经增加了该设置，程序结束时不会kill游戏。

若将来支持用户执行自定义命令行启动其他工具，例如`BGI`，则需要同样从job中分离


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - Windows 启动器新增管道模式（piped I/O），一键模式可用。
  - 按环境变量自动定位并启动脚本，遵循相关环境设置。

- 改进
  - 加强 Windows 进程生命周期管理：自动清理、可靠信号处理、继承子进程退出码。
  - 游戏启动与父进程解耦，避免父进程关闭导致游戏被终止，提升稳定性。

- Bug 修复
  - 在管道模式下改进退出与资源回收，降低悬挂与僵尸进程风险。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->