### PR TITLE
feat: 2.3适配

### DIFF
--- a/assets/game_data/compendium_data.yml
+++ b/assets/game_data/compendium_data.yml
@@ -107,6 +107,7 @@
         - mission_type_name: "伐木机"
         - mission_type_name: "秽息蚀者·阿瓦鲁斯"
         - mission_type_name: "牲鬼·凶魁愚者"
+        - mission_type_name: "秽蚀·狛野真斗"
         - mission_type_name: "代理人方案培养"
 
 - tab_name: "作战"
@@ -119,6 +120,7 @@
         - mission_type_name: "「霸主侵蚀体·庞培」"
         - mission_type_name: "牲鬼·布林格"
         - mission_type_name: "秽息司祭"
+        - mission_type_name: "彷徨猎手"
         - mission_type_name: "代理人方案培养"
     - category_name: "零号空洞"
       mission_type_list:

--- a/src/zzz_od/application/notorious_hunt/notorious_hunt_config.py
+++ b/src/zzz_od/application/notorious_hunt/notorious_hunt_config.py
@@ -62,7 +62,8 @@ class NotoriousHuntConfig(ApplicationConfig):
             ChargePlanItem('作战', '恶名狩猎', '冥宁芙·双子', None),
             ChargePlanItem('作战', '恶名狩猎', '「霸主侵蚀体·庞培」', None),
             ChargePlanItem('作战', '恶名狩猎', '牲鬼·布林格', None),
-            ChargePlanItem('作战', '恶名狩猎', '秽息司祭', None)
+            ChargePlanItem('作战', '恶名狩猎', '秽息司祭', None),
+            ChargePlanItem('作战', '恶名狩猎', '彷徨猎手', None)
         ]
 
     def save(self):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新功能
  * 图鉴新增两种任务类型：“秽蚀·狛野真斗”（专业挑战室）与“彷徨猎手”（恶名狩猎），可在相应分类中浏览与跟踪。
  * 恶名狩猎的默认计划新增“彷徨猎手”，初始化计划时将自动纳入，便于快速开始相关挑战与进度管理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->