### PR TITLE
fix: 迷失之地开局前选调查战略失败

### DIFF
--- a/assets/image_analysis_pipelines/调查战略等级圈圈.yml
+++ b/assets/image_analysis_pipelines/调查战略等级圈圈.yml
@@ -25,6 +25,7 @@
     mode: EXTERNAL
     method: SIMPLE
     draw_contours: 0
+    noise_threshold_ratio: 0.4  # 仅对此流水线使用更高噪点比例阈值, 此处需要大于0.3
 - step: 按长宽比过滤
   params:
     min_ratio: 0.9

--- a/assets/image_analysis_pipelines/调查战略等级圈圈.yml
+++ b/assets/image_analysis_pipelines/调查战略等级圈圈.yml
@@ -25,7 +25,6 @@
     mode: EXTERNAL
     method: SIMPLE
     draw_contours: 0
-#    noise_threshold_ratio: 0.4  # 仅对此流水线使用更高噪点比例阈值, 此处需要大于0.3
 - step: 按长宽比过滤
   params:
     min_ratio: 0.9

--- a/assets/image_analysis_pipelines/调查战略等级圈圈.yml
+++ b/assets/image_analysis_pipelines/调查战略等级圈圈.yml
@@ -25,7 +25,7 @@
     mode: EXTERNAL
     method: SIMPLE
     draw_contours: 0
-    noise_threshold_ratio: 0.4  # 仅对此流水线使用更高噪点比例阈值, 此处需要大于0.3
+#    noise_threshold_ratio: 0.4  # 仅对此流水线使用更高噪点比例阈值, 此处需要大于0.3
 - step: 按长宽比过滤
   params:
     min_ratio: 0.9

--- a/src/one_dragon/base/cv_process/steps/step_find_contours.py
+++ b/src/one_dragon/base/cv_process/steps/step_find_contours.py
@@ -27,7 +27,6 @@ class CvFindContoursStep(CvStep):
             'mode': {'type': 'enum', 'default': 'EXTERNAL', 'options': list(self.mode_map.keys()), 'label': '轮廓检索模式', 'tooltip': 'EXTERNAL:只找最外层轮廓。LIST:查找所有轮廓，不建立层次结构。TREE:建立完整层次结构。'},
             'method': {'type': 'enum', 'default': 'SIMPLE', 'options': list(self.method_map.keys()), 'label': '轮廓逼近方法', 'tooltip': 'SIMPLE:压缩水平、垂直和对角线段，只保留端点。NONE:存储所有轮廓点。'},
             'draw_contours': {'type': 'bool', 'default': True, 'label': '绘制轮廓', 'tooltip': '是否在调试图像上用绿色线条画出找到的轮廓。'},
-            # 'noise_threshold_ratio': {'type': 'float', 'default': 0.25, 'range': (0.0, 1.0), 'label': '噪点比例阈值', 'tooltip': '输入图像的白色像素比例若高于此值，则跳过轮廓查找以防止卡死。建议范围：0.1-0.4'},
         }
 
     def _execute(self, context: CvPipelineContext, mode: str = 'EXTERNAL', method: str = 'SIMPLE', draw_contours: bool = True, **_kwargs):
@@ -41,16 +40,6 @@ class CvFindContoursStep(CvStep):
             context.error_str = "错误：输入图像尺寸为0"
             context.success = False
             return
-
-        # white_pixels = cv2.countNonZero(context.mask_image)
-        # white_ratio = white_pixels / total_pixels
-        #
-        # if white_ratio > noise_threshold_ratio:
-        #     context.error_str = f"输入图像噪点过多 (白色像素比例 {white_ratio:.2f} > {noise_threshold_ratio})，跳过轮廓查找以防止卡死"
-        #     context.success = False
-        #     context.analysis_results.append(f"跳过轮廓查找：噪点比例 {white_ratio:.2f} 超过阈值 {noise_threshold_ratio}")
-        #     context.contours = []  # 清空轮廓列表
-        #     return
 
         cv2_mode = self.mode_map.get(mode)
         cv2_method = self.method_map.get(method)

--- a/src/one_dragon/base/cv_process/steps/step_find_contours.py
+++ b/src/one_dragon/base/cv_process/steps/step_find_contours.py
@@ -27,10 +27,10 @@ class CvFindContoursStep(CvStep):
             'mode': {'type': 'enum', 'default': 'EXTERNAL', 'options': list(self.mode_map.keys()), 'label': '轮廓检索模式', 'tooltip': 'EXTERNAL:只找最外层轮廓。LIST:查找所有轮廓，不建立层次结构。TREE:建立完整层次结构。'},
             'method': {'type': 'enum', 'default': 'SIMPLE', 'options': list(self.method_map.keys()), 'label': '轮廓逼近方法', 'tooltip': 'SIMPLE:压缩水平、垂直和对角线段，只保留端点。NONE:存储所有轮廓点。'},
             'draw_contours': {'type': 'bool', 'default': True, 'label': '绘制轮廓', 'tooltip': '是否在调试图像上用绿色线条画出找到的轮廓。'},
-            'noise_threshold_ratio': {'type': 'float', 'default': 0.25, 'range': (0.0, 1.0), 'label': '噪点比例阈值', 'tooltip': '输入图像的白色像素比例若高于此值，则跳过轮廓查找以防止卡死。建议范围：0.1-0.4'},
+            # 'noise_threshold_ratio': {'type': 'float', 'default': 0.25, 'range': (0.0, 1.0), 'label': '噪点比例阈值', 'tooltip': '输入图像的白色像素比例若高于此值，则跳过轮廓查找以防止卡死。建议范围：0.1-0.4'},
         }
 
-    def _execute(self, context: CvPipelineContext, mode: str = 'EXTERNAL', method: str = 'SIMPLE', draw_contours: bool = True, noise_threshold_ratio: float = 0.25, **_kwargs):
+    def _execute(self, context: CvPipelineContext, mode: str = 'EXTERNAL', method: str = 'SIMPLE', draw_contours: bool = True, **_kwargs):
         if context.mask_image is None:
             return
 
@@ -42,15 +42,15 @@ class CvFindContoursStep(CvStep):
             context.success = False
             return
 
-        white_pixels = cv2.countNonZero(context.mask_image)
-        white_ratio = white_pixels / total_pixels
-
-        if white_ratio > noise_threshold_ratio:
-            context.error_str = f"输入图像噪点过多 (白色像素比例 {white_ratio:.2f} > {noise_threshold_ratio})，跳过轮廓查找以防止卡死"
-            context.success = False
-            context.analysis_results.append(f"跳过轮廓查找：噪点比例 {white_ratio:.2f} 超过阈值 {noise_threshold_ratio}")
-            context.contours = []  # 清空轮廓列表
-            return
+        # white_pixels = cv2.countNonZero(context.mask_image)
+        # white_ratio = white_pixels / total_pixels
+        #
+        # if white_ratio > noise_threshold_ratio:
+        #     context.error_str = f"输入图像噪点过多 (白色像素比例 {white_ratio:.2f} > {noise_threshold_ratio})，跳过轮廓查找以防止卡死"
+        #     context.success = False
+        #     context.analysis_results.append(f"跳过轮廓查找：噪点比例 {white_ratio:.2f} 超过阈值 {noise_threshold_ratio}")
+        #     context.contours = []  # 清空轮廓列表
+        #     return
 
         cv2_mode = self.mode_map.get(mode)
         cv2_method = self.method_map.get(method)

--- a/src/one_dragon/base/cv_process/steps/step_find_contours.py
+++ b/src/one_dragon/base/cv_process/steps/step_find_contours.py
@@ -27,10 +27,10 @@ class CvFindContoursStep(CvStep):
             'mode': {'type': 'enum', 'default': 'EXTERNAL', 'options': list(self.mode_map.keys()), 'label': '轮廓检索模式', 'tooltip': 'EXTERNAL:只找最外层轮廓。LIST:查找所有轮廓，不建立层次结构。TREE:建立完整层次结构。'},
             'method': {'type': 'enum', 'default': 'SIMPLE', 'options': list(self.method_map.keys()), 'label': '轮廓逼近方法', 'tooltip': 'SIMPLE:压缩水平、垂直和对角线段，只保留端点。NONE:存储所有轮廓点。'},
             'draw_contours': {'type': 'bool', 'default': True, 'label': '绘制轮廓', 'tooltip': '是否在调试图像上用绿色线条画出找到的轮廓。'},
-            'noise_threshold_ratio': {'type': 'float', 'default': 0.25, 'range': (0.0, 1.0), 'label': '噪点比例阈值', 'tooltip': '输入图像的白色像素比例若高于此值，则跳过轮廓查找以防止卡死。建议范围：0.1-0.4'},
+            'noise_threshold_ratio': {'type': 'float', 'default': 0.45, 'range': (0.0, 1.0), 'label': '噪点比例阈值', 'tooltip': '输入图像的白色像素比例若高于此值，则跳过轮廓查找以防止卡死。建议范围：0.1-0.4'},
         }
 
-    def _execute(self, context: CvPipelineContext, mode: str = 'EXTERNAL', method: str = 'SIMPLE', draw_contours: bool = True, noise_threshold_ratio: float = 0.25, **_kwargs):
+    def _execute(self, context: CvPipelineContext, mode: str = 'EXTERNAL', method: str = 'SIMPLE', draw_contours: bool = True, noise_threshold_ratio: float = 0.45, **_kwargs):
         if context.mask_image is None:
             return
 

--- a/src/one_dragon/base/cv_process/steps/step_find_contours.py
+++ b/src/one_dragon/base/cv_process/steps/step_find_contours.py
@@ -27,10 +27,10 @@ class CvFindContoursStep(CvStep):
             'mode': {'type': 'enum', 'default': 'EXTERNAL', 'options': list(self.mode_map.keys()), 'label': '轮廓检索模式', 'tooltip': 'EXTERNAL:只找最外层轮廓。LIST:查找所有轮廓，不建立层次结构。TREE:建立完整层次结构。'},
             'method': {'type': 'enum', 'default': 'SIMPLE', 'options': list(self.method_map.keys()), 'label': '轮廓逼近方法', 'tooltip': 'SIMPLE:压缩水平、垂直和对角线段，只保留端点。NONE:存储所有轮廓点。'},
             'draw_contours': {'type': 'bool', 'default': True, 'label': '绘制轮廓', 'tooltip': '是否在调试图像上用绿色线条画出找到的轮廓。'},
-            'noise_threshold_ratio': {'type': 'float', 'default': 0.45, 'range': (0.0, 1.0), 'label': '噪点比例阈值', 'tooltip': '输入图像的白色像素比例若高于此值，则跳过轮廓查找以防止卡死。建议范围：0.1-0.4'},
+            'noise_threshold_ratio': {'type': 'float', 'default': 0.25, 'range': (0.0, 1.0), 'label': '噪点比例阈值', 'tooltip': '输入图像的白色像素比例若高于此值，则跳过轮廓查找以防止卡死。建议范围：0.1-0.4'},
         }
 
-    def _execute(self, context: CvPipelineContext, mode: str = 'EXTERNAL', method: str = 'SIMPLE', draw_contours: bool = True, noise_threshold_ratio: float = 0.45, **_kwargs):
+    def _execute(self, context: CvPipelineContext, mode: str = 'EXTERNAL', method: str = 'SIMPLE', draw_contours: bool = True, noise_threshold_ratio: float = 0.25, **_kwargs):
         if context.mask_image is None:
             return
 

--- a/src/zzz_od/application/hollow_zero/lost_void/lost_void_app.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/lost_void_app.py
@@ -256,7 +256,7 @@ class LostVoidApp(ZApplication):
                     log.debug("【追新模式】 找到一个未满级/无等级目标，准备点击。")
                     target_contour_to_click = frame_contour
                     break
-            
+
             if target_contour_to_click is not None:
                 M = cv2.moments(target_contour_to_click)
                 center_x = int(M["m10"] / M["m00"])
@@ -272,7 +272,7 @@ class LostVoidApp(ZApplication):
             self._swipe_strategy_list()
             self.screenshot()
             swipe_attempts += 1
-        
+
         # 回退逻辑: 选择第一个
         frame_context = self.ctx.cv_service.run_pipeline('调查战略等级圈圈', self.last_screenshot)
         if frame_context.is_success and frame_context.contours:

--- a/src/zzz_od/application/hollow_zero/lost_void/lost_void_app.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/lost_void_app.py
@@ -293,7 +293,8 @@ class LostVoidApp(ZApplication):
         """
         滑动调查战略列表
         """
-        start = Point(self.ctx.controller.standard_width // 2, self.ctx.controller.standard_height // 2)
+        # 调查战略的详情打开之后鼠标不能在详情处滑, 会滑不动
+        start = Point(self.ctx.controller.standard_width // 2, self.ctx.controller.standard_height // 2.5)
         end = start + Point(-800, 0)
         self.ctx.controller.drag_to(start=start, end=end)
         time.sleep(1)


### PR DESCRIPTION
两个bug:
- [迷失之地开局前选调查战略时, 详情打开之后鼠标不能在详情处滑, 会滑不动](https://github.com/OneDragon-Anything/ZenlessZoneZero-OneDragon/commit/3b556e3952cf1b89589e5c4aaff3483a2aa02092)
- [迷失之地增加开局前选调查战略时的噪点阈值避免返回空](https://github.com/OneDragon-Anything/ZenlessZoneZero-OneDragon/commit/5fc220fb957b46f243714be021a284cf7eba0c0d)
其中第二处修改我不知道白色像素比例从0.25改成0.45合不合适, 我的截图中白色像素占比是0.31左右 @kawayiYokami 
<img width="1920" height="1080" alt="错误截图" src="https://github.com/user-attachments/assets/07b2b383-e640-4308-9b4c-226cecfac639" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **Bug 修复**
  * 优化了滑动打开交互中的拖拽起始位置，改进了在详情视图上方操作的可靠性。
  * 移除了轮廓检测中的噪点跳过逻辑，确保轮廓查找流程更加稳定和一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->