### PR TITLE
fix：修复webhook推送中图片参数问题

### DIFF
--- a/src/one_dragon/base/push/channel/webhook.py
+++ b/src/one_dragon/base/push/channel/webhook.py
@@ -132,11 +132,16 @@ class Webhook(PushChannel):
             # 处理图片变量
             if "$image" in processed_body:
                 image_base64 = ""
-                if image:
-                    image_bytes = self.image_to_bytes(image)
-                    if image_bytes:
-                        image_bytes.seek(0)
-                        image_base64 = base64.b64encode(image_bytes.getvalue()).decode('utf-8')
+                if image is not None:  # image是MatLike，可能具有多个参数，此时if image会歧义
+                    try:
+                        image_bytes = self.image_to_bytes(image)
+                        if image_bytes:
+                            image_bytes.seek(0)
+                            image_base64 = base64.b64encode(image_bytes.getvalue()).decode('utf-8')
+                    except Exception as e:
+                        log.error(f"图片处理失败: {e}")
+                        image_base64 = ""
+    
                 processed_body = processed_body.replace("$image", image_base64)
 
             # 解析请求头


### PR DESCRIPTION
wenhook的图片处理代码中处理图片变量部分有参数验证错误，导致webhook的推送图片生成失败从而无法推送
<img width="638" height="486" alt="8FD50C5A6D14B57F827FB1BBFCAFCD30" src="https://github.com/user-attachments/assets/a5c1f379-379c-4159-a9e9-95a4cbe20d78" />

修复并添加异常处理后正常推送
<img width="637" height="477" alt="8AA055972DDE1F21BD7A20904FEA0657" src="https://github.com/user-attachments/assets/3948b026-f4a5-4cee-9ec0-21159515803f" />
![8AA36FF6128A9438810C404EE8B015DC](https://github.com/user-attachments/assets/d4d1c451-bc3a-4300-be14-1d891e3835ea)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Bug 修复**
  * 改进了图像处理的稳定性和容错能力，添加了异常处理机制。当图像处理失败时，系统现在能够优雅地降级处理，确保服务持续可用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->