### PR TITLE
去掉了ocr识别的切换按钮

### DIFF
--- a/src/one_dragon_qt/view/setting/resource_download_interface.py
+++ b/src/one_dragon_qt/view/setting/resource_download_interface.py
@@ -51,9 +51,13 @@ class ResourceDownloadInterface(VerticalScrollInterface):
         self.launcher_opt.check_and_update_display()
         group.addSettingCard(self.launcher_opt)
 
-        self.ocr_opt = OnnxModelDownloadCard(ctx=self.ctx, icon=FluentIcon.GLOBE, title='OCR识别')
+        self.ocr_opt = OnnxModelDownloadCard(
+            ctx=self.ctx,
+            icon=FluentIcon.GLOBE,
+            title='OCR识别',
+            enable_gpu_switch=False
+        )
         self.ocr_opt.value_changed.connect(self.on_ocr_changed)
-        self.ocr_opt.gpu_changed.connect(self.on_ocr_gpu_changed)
         group.addSettingCard(self.ocr_opt)
 
         self._add_model_cards(group)
@@ -76,13 +80,9 @@ class ResourceDownloadInterface(VerticalScrollInterface):
         self.ocr_opt.blockSignals(True)
         self.ocr_opt.set_options_by_list(get_ocr_opts())
         self.ocr_opt.set_value_by_save_file_name(f'{self.ctx.model_config.ocr}.zip')
-        self.ocr_opt.gpu_opt.setChecked(self.ctx.model_config.ocr_gpu)
         self.ocr_opt.check_and_update_display()
         self.ocr_opt.blockSignals(False)
 
     def on_ocr_changed(self, index: int, value: CommonDownloaderParam) -> None:
         self.ctx.model_config.ocr = value.save_file_name[:-4]
         self.ocr_opt.check_and_update_display()
-
-    def on_ocr_gpu_changed(self, value: bool) -> None:
-        self.ctx.model_config.ocr_gpu = value

--- a/src/one_dragon_qt/widgets/setting_card/onnx_model_download_card.py
+++ b/src/one_dragon_qt/widgets/setting_card/onnx_model_download_card.py
@@ -1,6 +1,6 @@
 from PySide6.QtCore import Signal
 from PySide6.QtGui import QIcon, Qt
-from qfluentwidgets import FluentIconBase, SwitchButton, IndicatorPosition
+from qfluentwidgets import FluentIconBase, SwitchButton, IndicatorPosition, BodyLabel
 from typing import Union
 
 from one_dragon.base.operation.one_dragon_context import OneDragonContext
@@ -17,13 +17,17 @@ class OnnxModelDownloadCard(ZipDownloaderSettingCard):
             icon: Union[str, QIcon, FluentIconBase],
             title: str,
             content=None,
-            parent=None
+            parent=None,
+            enable_gpu_switch=True  # 默认显示GPU开关
     ):
-        self.gpu_opt = SwitchButton(indicatorPos=IndicatorPosition.LEFT)
-        self.gpu_opt._offText = 'CPU'
-        self.gpu_opt._onText = 'GPU'
-        self.gpu_opt.label.setText(self.gpu_opt._offText)
-        self.gpu_opt.checkedChanged.connect(self.on_gpu_value_changed)
+        if enable_gpu_switch:
+            self.gpu_opt = SwitchButton(indicatorPos=IndicatorPosition.LEFT)
+            self.gpu_opt._offText = 'CPU'
+            self.gpu_opt._onText = 'GPU'
+            self.gpu_opt.label.setText(self.gpu_opt._offText)
+            self.gpu_opt.checkedChanged.connect(self.on_gpu_value_changed)
+        else:
+            self.gpu_opt = BodyLabel('CPU')
 
         ZipDownloaderSettingCard.__init__(
             self,


### PR DESCRIPTION
<img width="1643" height="1095" alt="743461492F715AE9BA07BE38CB21647A" src="https://github.com/user-attachments/assets/00c6dd1c-702b-4df4-b835-348fed0c2e35" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 版本更新说明

* **功能变更**
  * OCR 模型下载已禁用 GPU 切换选项，现仅显示 CPU 模式。
  * 移除了 OCR GPU 状态的自动保存功能。
  * 简化了 OCR 设置界面的交互流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->