### PR TITLE
fix: 在钉钉机器人消息渠道的标题中添加内容，以便钉钉消息在系统通知栏能显示具体步骤

### DIFF
--- a/src/one_dragon/base/push/channel/dingding.py
+++ b/src/one_dragon/base/push/channel/dingding.py
@@ -88,12 +88,12 @@ class DingDingBot(PushChannel):
             # 生成时间戳和签名
             timestamp = str(round(time.time() * 1000))
             sign = self._generate_sign(secret, timestamp)
-
             # 构建消息内容
             message_data = {
                 "msgtype": "markdown",
                 "markdown": {
-                    "title": title,
+                    "title": f"{title}\n{content}",
+                    #需要在"title"中添加消息具体内容{content},否则钉钉在系统通知栏只显示{title}部分无法识别对应的具体步骤
                     "text": f"## {title}\n\n{content}"
                 }
             }


### PR DESCRIPTION
更改前,钉钉的系统通知只显示标题 
![fd4893ca895311869f955ebb79a4af20](https://github.com/user-attachments/assets/866c3032-3a6d-42fe-9627-37a2813e251a)
更改后,钉钉系统通知能够正常显示具体的通知运行步骤消息
![6e1656d544130ade96a70a821959765c](https://github.com/user-attachments/assets/b959ffe0-39be-40ca-ab44-c433185f463f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **Bug Fixes**
  * 改进了钉钉推送通知中 Markdown 消息的标题显示格式，现在标题部分会包含完整的消息内容，提升了通知的信息完整性和可读性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->