### PR TITLE
fix: 修复（闪避助手）自动战斗上下文初始化方法调用

### DIFF
--- a/src/zzz_od/application/battle_assistant/dodge_assitant/dodge_assistant_app.py
+++ b/src/zzz_od/application/battle_assistant/dodge_assitant/dodge_assistant_app.py
@@ -61,7 +61,7 @@ class DodgeAssistantApp(ZApplication):
         :return:
         """
         try:
-            self.ctx.init_auto_op(
+            self.ctx.auto_battle_context.init_auto_op(
                 sub_dir='dodge',
                 op_name=self.ctx.battle_assistant_config.dodge_assistant_config
             )


### PR DESCRIPTION
闪避助手执行出错，AttributeError: 'ZContext' object has no attribute 'init_auto_op'，高度关联 #1645 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 优化了闪避助手的初始化流程，使用改进的上下文路径机制加载操作配置，增强了系统的灵活性和可维护性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->