### PR TITLE
fix: 修复迷失之地小概率会在通用选择节点卡住的问题

### DIFF
--- a/src/zzz_od/application/hollow_zero/lost_void/context/lost_void_context.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/context/lost_void_context.py
@@ -446,7 +446,7 @@ class LostVoidContext:
                 elif title_idx == 3:  # NEW!
                     closest_artifact_pos.is_new = True
 
-        artifact_pos_list = [i for i in artifact_pos_list if i.can_choose]
+        # artifact_pos_list = [i for i in artifact_pos_list if i.can_choose]  # 这行导致了chosen_list只会是空的
 
         display_text = ', '.join([i.artifact.display_name for i in artifact_pos_list]) if len(artifact_pos_list) > 0 else '无'
         log.info(f'当前识别藏品 {display_text}')

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/interact/lost_void_choose_common.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/interact/lost_void_choose_common.py
@@ -42,7 +42,8 @@ class LostVoidChooseCommon(ZOperation):
         art_list, chosen_list = self.get_artifact_pos(self.last_screenshot)
         art: Optional[LostVoidArtifactPos] = None
         if self.to_choose_num > 0:
-            if len(art_list) == 0:
+            if len(art_list) == 0 and len(chosen_list) == 0:  # 已选和可选都没有才算没有
+                # 如果初始可选=0 已选=1 即自动战斗结束不及时导致误点屏幕中心选到了卡牌 且正好为单选 会一直无法识别而卡住 而不是去直接点确认 这种小概率情况会出现在秘宝猎人战略
                 return self.round_retry(status='无法识别藏品', wait=1)
 
             priority_list: list[LostVoidArtifactPos] = self.ctx.lost_void.get_artifact_by_priority(
@@ -178,7 +179,7 @@ class LostVoidChooseCommon(ZOperation):
 
 def __debug():
     ctx = ZContext()
-    ctx.init_by_config()
+    ctx.init()
     ctx.init_ocr()
     ctx.lost_void.init_before_run()
     ctx.run_context.start_running()
@@ -189,13 +190,13 @@ def __debug():
 
 def __get_get_artifact_pos():
     ctx = ZContext()
-    ctx.init_by_config()
+    ctx.init()
     ctx.init_ocr()
     ctx.lost_void.init_before_run()
 
     op = LostVoidChooseCommon(ctx)
     from one_dragon.utils import debug_utils
-    screen = debug_utils.get_debug_image('484035848-554c6a8d-340e-404d-ab88-8baac21637ca')
+    screen = debug_utils.get_debug_image('20251112133547')
     art_list, chosen_list = op.get_artifact_pos(screen)
     print(len(art_list), len(chosen_list))
     cv2_utils.show_image(screen, chosen_list[0] if len(chosen_list) > 0 else None, wait=0)
@@ -204,4 +205,4 @@ def __get_get_artifact_pos():
 
 
 if __name__ == '__main__':
-    __get_get_artifact_pos()
+    __debug()


### PR DESCRIPTION
![3](https://github.com/user-attachments/assets/8c6dae6f-20c4-43a9-97e7-11fc01f007fc)

补充：连续测试了7把完整迷失之地成功了5把，有2把是因为转向识别下一层没识别到自己退出了，暂时没发现有其他问题


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发布说明

* **Bug 修复**
  * 扩展了人工制品的可选范围，现在将展示更多可用选项。
  * 优化了人工制品选择的重试逻辑，改进了选择机制。

* **其他**
  * 更新了调试和初始化相关配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->