### PR TITLE
fix: 修复迷失之地已选择藏品返回无法识别藏品的问题

### DIFF
--- a/src/zzz_od/application/hollow_zero/lost_void/context/lost_void_context.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/context/lost_void_context.py
@@ -446,7 +446,9 @@ class LostVoidContext:
                 elif title_idx == 3:  # NEW!
                     closest_artifact_pos.is_new = True
 
-        artifact_pos_list = [i for i in artifact_pos_list if i.can_choose]
+        # 修复：不再在这里过滤can_choose的藏品，由调用方get_artifact_pos自行处理
+        # 这样可以确保已选择的藏品信息也能正确返回，避免"无法识别藏品"的问题
+        # 原始代码：artifact_pos_list = [i for i in artifact_pos_list if i.can_choose]
 
         display_text = ', '.join([i.artifact.display_name for i in artifact_pos_list]) if len(artifact_pos_list) > 0 else '无'
         log.info(f'当前识别藏品 {display_text}')
@@ -474,15 +476,15 @@ class LostVoidContext:
         artifact_list = self.remove_overlapping_artifacts(artifact_list)
 
         log.info(f'当前考虑优先级 数量={choose_num} NEW!={consider_priority_new} 第一优先级={consider_priority_1} 第二优先级={consider_priority_2} 其他={consider_not_in_priority}')
-        
+
         # 合并动态优先级和静态优先级
         priority_list_to_consider = []
-        
+
         final_priority_list_1 = self.dynamic_priority_list.copy()
         if consider_priority_1 and self.challenge_config.artifact_priority:
             final_priority_list_1.extend(self.challenge_config.artifact_priority)
         priority_list_to_consider.append(final_priority_list_1)
-        
+
         if consider_priority_2 and self.challenge_config.artifact_priority_2:
             priority_list_to_consider.append(self.challenge_config.artifact_priority_2)
 

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/interact/lost_void_choose_common.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/interact/lost_void_choose_common.py
@@ -43,7 +43,10 @@ class LostVoidChooseCommon(ZOperation):
         art: Optional[LostVoidArtifactPos] = None
         if self.to_choose_num > 0:
             if len(art_list) == 0:
-                return self.round_retry(status='无法识别藏品', wait=1)
+                if len(chosen_list) > 0:
+                    log.debug(f"检测到已选择 {len(chosen_list)} 个藏品，跳过选择步骤")
+                else:
+                    return self.round_retry(status='无法识别藏品', wait=1)
 
             priority_list: list[LostVoidArtifactPos] = self.ctx.lost_void.get_artifact_by_priority(
                 art_list, self.to_choose_num,
@@ -189,18 +192,17 @@ def __debug():
 
 def __get_get_artifact_pos():
     ctx = ZContext()
-    ctx.init_by_config()
-    ctx.init_ocr()
+    ctx.init()
     ctx.lost_void.init_before_run()
 
     op = LostVoidChooseCommon(ctx)
     from one_dragon.utils import debug_utils
-    screen = debug_utils.get_debug_image('484035848-554c6a8d-340e-404d-ab88-8baac21637ca')
+    screen = debug_utils.get_debug_image('123')
     art_list, chosen_list = op.get_artifact_pos(screen)
     print(len(art_list), len(chosen_list))
-    cv2_utils.show_image(screen, chosen_list[0] if len(chosen_list) > 0 else None, wait=0)
     import cv2
-    cv2.destroyAllWindows()
+    # cv2_utils.show_image(screen, chosen_list[0] if len(chosen_list) > 0 else None, wait=0)
+    # cv2.destroyAllWindows()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- 修复choose_artifact方法中的业务逻辑缺陷
- 当藏品已被选择时，系统现在会跳过选择步骤，直接进入确定流程
- 移除get_artifact_pos中的过度过滤，确保已选择藏品信息正确返回
- 解决了已选择状态被错误识别为'无法识别藏品'的问题
- 测试方法现在可以直接测试

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Bug Fixes**
  * 修复了藏品选择时已选物品信息丢失导致识别失败的问题
  * 优化了藏品无法识别时的处理逻辑，减少不必要的重试

<!-- end of auto-generated comment: release notes by coderabbit.ai -->