### PR TITLE
fix: 修复等待操作在新架构下无法中断的BUG

### DIFF
--- a/src/zzz_od/auto_battle/atomic_op/wait.py
+++ b/src/zzz_od/auto_battle/atomic_op/wait.py
@@ -1,4 +1,3 @@
-import time
 import threading
 from typing import ClassVar
 
@@ -12,14 +11,14 @@ class AtomicWait(AtomicOp):
 
     def __init__(self, op_def: OperationDef):
         wait_seconds = op_def.wait_seconds
-        if op_def.data is not None:
-            if len(op_def.data) > 0:
-                wait_seconds = float(op_def.data[0])
-        AtomicOp.__init__(self, op_name='%s %.2f' % (AtomicWait.OP_NAME, wait_seconds))
+        if op_def.data is not None and len(op_def.data) > 0:
+            wait_seconds = float(op_def.data[0])
+        AtomicOp.__init__(self, op_name=f'{AtomicWait.OP_NAME} {wait_seconds:.2f}')
         self.wait_seconds: float = wait_seconds
         self._stop_event = threading.Event()  # 用于中断的Event
 
     def execute(self):
+        self._stop_event.clear()
         # 使用 wait() 而不是 sleep()，这样可以被 stop() 中断
         self._stop_event.wait(timeout=self.wait_seconds)
 


### PR DESCRIPTION
新架构下，原子操作需要由自己打断。但是等待操作并没有提供打断sleep的功能。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 增强等待操作的中断能力，支持在等待期间被及时停止。
  * 替换基于固定延迟的等待机制为可中断的等待，提升响应性。
  * 操作显示名称精度优化（保留两位小数），便于监控与识别。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->