### PR TITLE
perf: 优化hdd副本的选择准确性

### DIFF
--- a/src/one_dragon/base/operation/operation.py
+++ b/src/one_dragon/base/operation/operation.py
@@ -973,8 +973,7 @@ class Operation(OperationBase):
 
         click = self.ctx.controller.click(to_click)
         if click:
-            # 将点击坐标通过 data 返回，便于调用方进行同位置的二次点击等后续操作
-            return self.round_success(target_cn, data=to_click, wait=success_wait, wait_round_time=success_wait_round)
+            return self.round_success(target_cn, wait=success_wait, wait_round_time=success_wait_round)
         else:
             return self.round_retry(f'点击 {target_cn} 失败', wait=retry_wait, wait_round_time=retry_wait_round)
 
@@ -1042,7 +1041,7 @@ class Operation(OperationBase):
                 to_click = to_click + offset
 
             self.ctx.controller.click(to_click)
-            return self.round_success(status=match_word, data=to_click, wait=success_wait, wait_round_time=success_wait_round)
+            return self.round_success(status=match_word, wait=success_wait, wait_round_time=success_wait_round)
 
         return self.round_retry(status='未匹配到目标文本', wait=retry_wait, wait_round_time=retry_wait_round)
 

--- a/src/zzz_od/application/life_on_line/life_on_line_app.py
+++ b/src/zzz_od/application/life_on_line/life_on_line_app.py
@@ -1,6 +1,5 @@
 import time
-
-from typing import ClassVar, Optional
+from typing import ClassVar
 
 from one_dragon.base.operation.application import application_const
 from one_dragon.base.operation.operation_edge import node_from
@@ -200,6 +199,7 @@ class LifeOnLineApp(ZApplication):
 def __debug():
     ctx = ZContext()
     ctx.init()
+    ctx.run_context.start_running()
     app = LifeOnLineApp(ctx)
     app.execute()
 

--- a/src/zzz_od/auto_battle/atomic_op/atomic_op_factory.py
+++ b/src/zzz_od/auto_battle/atomic_op/atomic_op_factory.py
@@ -45,10 +45,12 @@ class AtomicOpFactory:
         # 有几个特殊参数 在这里统一提取
         press: bool = op_name.endswith('-按下')
         release: bool = op_name.endswith('-松开')
+        press_time = None
         if press:
-            press_time = float(op_data[0]) if (op_data is not None and len(op_data) > 0) else None
-        else:
-            press_time = None
+            if op_def.btn_press is not None:
+                press_time = op_def.btn_press
+            elif op_data is not None and len(op_data) > 0:
+                press_time = float(op_data[0])
 
         if op_name == AtomicBtnSwitchAgent.OP_NAME or op_name == '切换角色':
             # 切换角色 只是一个兼容 后续删掉

--- a/src/zzz_od/operation/hdd/enter_hdd_mission.py
+++ b/src/zzz_od/operation/hdd/enter_hdd_mission.py
@@ -1,3 +1,5 @@
+import time
+
 from one_dragon.base.geometry.point import Point
 from one_dragon.base.operation.operation_edge import node_from
 from one_dragon.base.operation.operation_node import operation_node
@@ -72,10 +74,9 @@ class EnterHddMission(ZOperation):
         area = self.ctx.screen_loader.get_area('HDD', '副本区域')
         result = self.round_by_ocr_and_click(self.last_screenshot, self.mission_name, area=area)
         if result.is_success:
-            # 使用首次点击返回的坐标再次点击，确保在同一位置完成双击保障
-            to_click = result.data
-            if to_click is not None:
-                self.ctx.controller.click(pos=to_click)
+            # 有时候点击会失败 这里多点击一次确保成功
+            time.sleep(1)
+            self.round_by_ocr_and_click(self.last_screenshot, self.mission_name, area=area)
             return self.round_success(wait=1)
 
         # 找不到时候 往下滑


### PR DESCRIPTION
[游戏助手] #1626 更新后拿命验收无法运行 #1659
[游戏助手] 游戏助手-拿命验收未能正确执行 #1671 
[游戏助手] 真。拿命驗收 新BUG 妮可的向前攻擊變成後撤攻擊 #1688
————————————
[游戏助手] 拿命驗收 請求修正 只要兩秒 #1684

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 提升任务/章节选择稳定性：加入双击防护，调整多处等待时长（部分成功路径延长为 wait=2），并在成功后将点击坐标回传以便后续操作。

* **Chores**
  * 优化调试启动流程以改进启动稳定性。
  * 更新操作配置：新增按压行为占位（press: null）以更清晰表示未设置状态。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->