### PR TITLE
fix: 修复国服切换账号登录时可能会卡住的问题

### DIFF
--- a/assets/game_data/screen_info/enter_game.yml
+++ b/assets/game_data/screen_info/enter_game.yml
@@ -450,3 +450,17 @@ area_list:
   template_match_threshold: 0.7
   color_range: null
   goto_list: []
+- area_name: 国服-返回按钮
+  id_mark: false
+  pc_rect:
+  - 538
+  - 222
+  - 575
+  - 265
+  text: ''
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  color_range: null
+  goto_list: []

--- a/src/zzz_od/operation/enter_game/enter_game.py
+++ b/src/zzz_od/operation/enter_game/enter_game.py
@@ -12,7 +12,6 @@ from one_dragon.base.matcher.ocr import ocr_utils
 from one_dragon.base.operation.operation_edge import node_from
 from one_dragon.base.operation.operation_node import operation_node
 from one_dragon.base.operation.operation_round_result import OperationRoundResult
-from one_dragon.utils import cv2_utils, str_utils
 from one_dragon.utils.i18_utils import gt
 from zzz_od.context.zzz_context import ZContext
 from zzz_od.operation.zzz_operation import ZOperation
@@ -55,21 +54,11 @@ class EnterGame(ZOperation):
         if interact_result is not None:
             return interact_result
 
-        # 处理国服登录时账号或密码输入框为空的错误 适用于Ctrl+V有小概率没粘贴上的情况 直接返回重试
-        login_prompts = [
-            ('国服-账号输入区域-新', gt('输入手机号/邮箱', 'game')),
-            ('国服-密码输入区域-新', gt('输入密码', 'game')),
-        ]
-
-        for area_name, prompt_text in login_prompts:
-            area = self.ctx.screen_loader.get_area('打开游戏', area_name)
-            part = cv2_utils.crop_image_only(self.last_screenshot, area.rect)
-            ocr_result_map = self.ctx.ocr.run_ocr(part)
-
-            for ocr_result in ocr_result_map.keys():
-                if str_utils.find_by_lcs(prompt_text, ocr_result, percent=0.5):
-                    self.round_by_click_area('打开游戏', '国服-返回按钮')
-                    return self.round_retry(status='返回重试', wait=1)
+        # 处理国服登录时账号密码输入有误的情况 通过登录按钮文本判断可能没登录成功 尝试返回重试
+        result = self.round_by_find_area(self.last_screenshot, '打开游戏', '国服-账号密码进入游戏-新')
+        if result.is_success:
+            self.round_by_click_area('打开游戏', '国服-返回按钮')
+            return self.round_retry(status='返回重试', wait=1)
 
         # 判定是否进入大世界
         world_screens = ['大世界-普通', '大世界-勘域']


### PR DESCRIPTION
实际运行中出现的情况，有小概率会文本没粘贴上，在这里会未知画面卡住而结束
![case](https://github.com/user-attachments/assets/27cd27ed-749c-4ed8-8afa-09666fadedce)

解决方案，识别任一输入区域有初始提示文本则点击返回重试
![case1](https://github.com/user-attachments/assets/a2bc46d2-7c9a-4efd-8aae-291344817514)
![case2](https://github.com/user-attachments/assets/26dce00b-7318-4649-8a6b-b211e5401786)

局限性
1. 只适用于使用输入方式为剪贴板，如果使用键盘输入有错误，输入区域不是空的话还是会卡住，可能需要其他判断方案
2. 理论上如果官服会卡住的话，其他服也一样有概率会出现这个问题，但我没法测试其他服的情况，所以只处理了官服的情况

补充：想到了另一种方案，识别登录按钮如果还在就点击返回重试
这种处理应该也会适用于输入方式为键盘输入且有错误的情况，除非本身配置的账号密码就是错的，不然应该不太可能会多次出错导致出现验证码卡住

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **New Features**
  * 新增国服界面识别点“国服-返回按钮”，用于界面交互与流程控制。

* **Bug Fixes**
  * 优化国服登录流程：在检测到特定登录界面时会尝试使用新增返回按钮进行重试，提升登录稳定性与自动化鲁棒性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->