### PR TITLE
perf: 优化一下交互点识别，改用普攻按钮丢失来判定，可以光速停下

### DIFF
--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
@@ -390,6 +390,8 @@ class LostVoidRunLevel(ZOperation):
         time.sleep(0.2)
         self.ctx.controller.move_s(press=True, press_time=0.2, release=True)
         time.sleep(0.2)
+        self.ctx.controller.move_s(press=True, press_time=0.2, release=True)
+        time.sleep(0.2)
         self.ctx.controller.move_w(press=True, press_time=0.2, release=True)
         time.sleep(1)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 调整互动判定逻辑：通过优先检测普通攻击按钮并基于图标尺寸变化判断是否到达互动点，减少误判。
  * 优化互动流程与移动节奏：在判定停止并重试前加入短暂停顿和刷新检测；在重试路径上增加一次前进步伐与短暂等待，提升互动触发稳定性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->