### PR TITLE
fix: 修复 check_interact_stop 方法的逻辑问题

### DIFF
--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
@@ -499,32 +499,32 @@ class LostVoidMoveByDet(ZOperation):
 
         # 1. 先检查交互按钮
         result = self.round_by_find_area(screen, '战斗画面', '按键-交互')
-        if result.is_success:
-            return True
+        if not result.is_success:
+            # 没有交互按钮，检查普攻按钮是否丢失
+            result = self.round_by_find_area(screen, '战斗画面', '按键-普通攻击')
+            if not result.is_success:
+                # 普攻按钮丢失，检查距离上次停下是否超过5秒
+                current_time = time.time()
+                if current_time - self._last_attack_btn_check_time >= 5:
+                    # 执行停下动作，并记录时间
+                    self._last_attack_btn_check_time = current_time
+                    self.ctx.controller.stop_moving_forward()
+                    time.sleep(0.5)
+            return False
 
         # 2. 检测图标是否变大
         for result in frame_result.results:
             if result.detect_class.class_name == LostVoidDetector.CLASS_DISTANCE:
+                # 不考虑 [距离]白点
                 continue
 
             if result.detect_class.class_name == LostVoidDetector.CLASS_INTERACT:
-                min_width = 70
+                min_width = 70  # 感叹号的图标会大一点
             else:
-                min_width = 50
+                min_width = 50  # 普通入口的图标
 
             if result.width > min_width and result.height > min_width:
                 return True
-
-        # 3. 检查普攻按钮是否丢失
-        result = self.round_by_find_area(screen, '战斗画面', '按键-普通攻击')
-        if not result.is_success:
-            # 普攻按钮丢失，检查距离上次停下是否超过5秒
-            current_time = time.time()
-            if current_time - self._last_attack_btn_check_time >= 5:
-                # 执行停下动作，并记录时间
-                self._last_attack_btn_check_time = current_time
-                self.ctx.controller.stop_moving_forward()
-                time.sleep(0.5)
 
         return False
 


### PR DESCRIPTION
- 修复交互检测逻辑：只有在有交互按钮时才检查图标大小
- 将普攻按钮丢失检查移至没有交互按钮的分支

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **缺陷修复**
  * 增强交互检测的容错能力，当主交互方式不可用时自动尝试备用方案。
  * 优化移动停止判断逻辑，添加时间验证机制以提高稳定性。
  * 简化内部代码结构，无API破坏性变更。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->