### PR TITLE
修复随便观托管死循环问题

### DIFF
--- a/src/zzz_od/application/suibian_temple/operations/suibian_temple_auto_manage.py
+++ b/src/zzz_od/application/suibian_temple/operations/suibian_temple_auto_manage.py
@@ -35,7 +35,7 @@ class SuibianTempleAutoManage(ZOperation):
             elif result.status == '确认':
                 return self.round_wait(status='点击确认', wait=1)
             elif result.status == '托管中':
-                return self.round_wait(status='点击进入托管详情', wait=1)
+                return self.round_success(status='已在托管中')
 
         return self.round_retry(status='未识别有效按钮', wait=1)
 


### PR DESCRIPTION
## 问题描述
在随便观自动托管功能中，当OCR识别到"托管中"状态时，代码会进入死循环。
 
## 根本原因
因为"托管中"不止左下角有，画面中间也有一个"托管中"，这个更优先被OCR识别到，导致代码进入错误的处理分支。
 
## 解决方案
我认为"托管中"状态说明运行良好，就不需要作处理了，直接返回成功即可。
 
## 修改效果
- ✅ 解决死循环问题
- ✅ 正确识别托管状态为完成状态
- ✅ 提升自动托管的可靠性
 
## 测试建议
在随便观托管界面测试，确认能正确识别"托管中"状态并正常结束流程。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **错误修复**
  * 优化了托管状态检查逻辑，当检测到托管进行中时，系统现将其正确标记为成功状态，提升用户操作流畅度。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->