### PR TITLE
切换账号后渲染体力计划列表页面时, 先清空再渲染以防止部分信息未更新导致的错乱

### DIFF
--- a/src/zzz_od/gui/view/one_dragon/charge_plan_interface.py
+++ b/src/zzz_od/gui/view/one_dragon/charge_plan_interface.py
@@ -371,26 +371,21 @@ class ChargePlanInterface(VerticalScrollInterface):
     def update_plan_list_display(self):
         plan_list = self.config.plan_list
 
-        if len(plan_list) > len(self.card_list):
-            # 需要添加新的卡片
-            while len(self.card_list) < len(plan_list):
-                idx = len(self.card_list)
-                card = ChargePlanCard(self.ctx, idx, self.config.plan_list[idx],
-                                      config=self.config)
-                card.changed.connect(self._on_plan_item_changed)
-                card.delete.connect(self._on_plan_item_deleted)
-                card.move_top.connect(self._on_plan_item_move_top)
+        # 清空原来的卡片再创建新的卡片, 以防止部分信息未更新
+        self.drag_list.clear()
+        self.card_list.clear()
+        idx = 0
+        while idx < len(plan_list):
+            card = ChargePlanCard(self.ctx, idx, self.config.plan_list[idx],
+                                  config=self.config)
+            card.changed.connect(self._on_plan_item_changed)
+            card.delete.connect(self._on_plan_item_deleted)
+            card.move_top.connect(self._on_plan_item_move_top)
 
-                self.card_list.append(card)
-                # 使用 DraggableList 的 add_list_item 方法直接添加 ChargePlanCard
-                self.drag_list.add_list_item(card)
-
-        elif len(plan_list) < len(self.card_list):
-            # 需要移除多余的卡片
-            while len(self.card_list) > len(plan_list):
-                card = self.card_list[-1]
-                self.drag_list.remove_item(len(self.card_list) - 1)
-                self.card_list.pop(-1)
+            self.card_list.append(card)
+            # 使用 DraggableList 的 add_list_item 方法直接添加 ChargePlanCard
+            self.drag_list.add_list_item(card)
+            idx += 1
 
         # 更新所有卡片的显示
         for idx, plan in enumerate(plan_list):


### PR DESCRIPTION
修复使用以下方式能够复现的bug:
1. 添加测试账号1和2，在每个账号中创建不同的体力计划(每个账号至少创建2条以便查看) (当前激活测试账号2)
2. 重启一条龙并跳转至体力计划 (当前激活测试账号2)
3. 切换至账号1
4. 拖拽账号1的体力计划
5. 重启一条龙后会发现账号1的体力计划项目变成了账号2的体力计划项目

另外，这段代码在 `charge_plan_setting_dialog.py` 中也出现了，但是貌似那边只处理了 `len(plan_list) > len(self.card_list)` 的情况，我调试的时候也没进断点，于是我没动那块的代码

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 修复与改进

* **Bug Fixes**
  * 优化了充能计划列表的显示更新机制，确保列表内容与当前计划状态保持同步。

* **Refactor**
  * 调整了计划列表界面的刷新逻辑，改进了界面响应的稳定性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->