### PR TITLE
fix: 优化锄大地坐标识别和转向容错

### DIFF
--- a/src/zzz_od/application/world_patrol/operation/world_patrol_run_route.py
+++ b/src/zzz_od/application/world_patrol/operation/world_patrol_run_route.py
@@ -308,7 +308,9 @@ class WorldPatrolRunRoute(ZOperation):
             self.current_pos = next_pos
             return None
 
-    def _is_next_pos_valid(self, next_pos: Point) -> bool:
+    def _is_next_pos_valid(self, next_pos: Point | None) -> bool:
+        if next_pos is None:
+            return False
         """
         判断匹配的下一个坐标是否合法
         1. 距离检查：防止基准点错误导致的大幅跳跃


### PR DESCRIPTION
fixes: #1691 
fix: #1700 

# 完整修改总结

- 我遇到的核心问题
坐标连续舍弃导致角色卡死

- 日志表现：
[log.txt](https://github.com/user-attachments/files/24796834/log.txt)
当前坐标 (649, 1874) 目标点 (626, 1804)
计算坐标偏移较大 舍弃 (550, 1819)
...连续舍弃 30+ 次
坐标计算失败 持续 4.06 秒
根本原因：基准点错误 + 角度容错太窄 → 所有新坐标被舍弃 → 死循环

- 本次修改
  - 通过三层防护机制放宽容错、距离限制、状态重置解决坐标连续舍弃问题：
放宽容错（30度 + 50像素）：提升对 OCR 坐标抖动的容错能力；短距离移动时跳过角度检查，避免误判
距离限制（100像素）：防止基准点错误导致的死循环，快速触发脱困
状态重置（灵敏度）：战斗后切换角色后重置转向灵敏度，避免携带错误的转向校准值
  - 额外的更改：
快速脱困（1.5秒停止 + 4.5秒脱困 + 13.5秒重启）：更快响应坐标失败，减少等待时间

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* 优化世界巡逻路线导航的坐标稳定性，调整故障转移时序以更早触发重启，减少失控行为。
* 增加位置距离验证机制，防止无效的导航目标。
* 提高角度偏差容限，提升对视觉识别偏差的容错能力。

## Refactor

* 优化战斗后的方向控制状态重置，确保后续移动的一致性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->