### PR TITLE
fix: 零号空洞boss关卡检测调整

### DIFF
--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -5267,6 +5267,20 @@
     color_range: null
     goto_list: []
     gamepad_key: menu
+  - area_name: 标识-BOSS血条
+    id_mark: false
+    pc_rect:
+    - 1620
+    - 16
+    - 1720
+    - 106
+    text: ''
+    lcs_percent: 0.5
+    template_sub_dir: battle
+    template_id: boss_life
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
   - area_name: 区域-对话内容
     id_mark: false
     pc_rect:

--- a/assets/game_data/screen_info/lost_void_normal_world.yml
+++ b/assets/game_data/screen_info/lost_void_normal_world.yml
@@ -88,6 +88,20 @@ area_list:
   color_range: null
   goto_list: []
   gamepad_key: menu
+- area_name: 标识-BOSS血条
+  id_mark: false
+  pc_rect:
+  - 1620
+  - 16
+  - 1720
+  - 106
+  text: ''
+  lcs_percent: 0.5
+  template_sub_dir: battle
+  template_id: boss_life
+  template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 区域-对话内容
   id_mark: false
   pc_rect:

--- a/src/zzz_od/application/hollow_zero/lost_void/context/lost_void_context.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/context/lost_void_context.py
@@ -151,11 +151,7 @@ class LostVoidContext:
         return False
 
     def is_boss_health_bar_present(self, screen: MatLike) -> bool:
-        """
-        判断当前画面是否已经出现BOSS血条
-        @param screen: 游戏画面
-        @return:
-        """
+        """判断当前画面是否已出现 BOSS 血条。"""
         result = screen_utils.find_area(self.ctx, screen, '迷失之地-大世界', '标识-BOSS血条')
         return result == FindAreaResultEnum.TRUE
 

--- a/src/zzz_od/application/hollow_zero/lost_void/context/lost_void_context.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/context/lost_void_context.py
@@ -150,6 +150,15 @@ class LostVoidContext:
 
         return False
 
+    def is_boss_health_bar_present(self, screen: MatLike) -> bool:
+        """
+        判断当前画面是否已经出现BOSS血条
+        @param screen: 游戏画面
+        @return:
+        """
+        result = screen_utils.find_area(self.ctx, screen, '迷失之地-大世界', '标识-BOSS血条')
+        return result == FindAreaResultEnum.TRUE
+
     def detect_to_go(self, screen: MatLike, screenshot_time: float, ignore_list: Optional[List[str]] = None) -> DetectFrameResult:
         """
         识别需要前往的内容

--- a/src/zzz_od/application/hollow_zero/lost_void/context/lost_void_context.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/context/lost_void_context.py
@@ -1,7 +1,6 @@
 import os
-import time
-from typing import Optional, List, Tuple
 import re
+import time
 
 from cv2.typing import MatLike
 
@@ -9,17 +8,18 @@ from one_dragon.base.config.yaml_operator import YamlOperator
 from one_dragon.base.operation.application import application_const
 from one_dragon.base.screen import screen_utils
 from one_dragon.base.screen.screen_utils import FindAreaResultEnum
-from one_dragon.utils import os_utils, str_utils, cv2_utils
+from one_dragon.utils import cv2_utils, os_utils, str_utils
 from one_dragon.utils.i18_utils import gt
 from one_dragon.utils.log_utils import log
 from one_dragon.yolo.detect_utils import DetectFrameResult
 from zzz_od.application.hollow_zero.lost_void import lost_void_const
 from zzz_od.application.hollow_zero.lost_void.context.lost_void_artifact import LostVoidArtifact
 from zzz_od.application.hollow_zero.lost_void.context.lost_void_detector import LostVoidDetector
-from zzz_od.application.hollow_zero.lost_void.context.lost_void_investigation_strategy import \
-    LostVoidInvestigationStrategy
-from zzz_od.application.hollow_zero.lost_void.lost_void_challenge_config import LostVoidRegionType, \
-    LostVoidChallengeConfig
+from zzz_od.application.hollow_zero.lost_void.context.lost_void_investigation_strategy import LostVoidInvestigationStrategy
+from zzz_od.application.hollow_zero.lost_void.lost_void_challenge_config import (
+    LostVoidChallengeConfig,
+    LostVoidRegionType,
+)
 from zzz_od.application.hollow_zero.lost_void.lost_void_config import LostVoidConfig
 from zzz_od.application.hollow_zero.lost_void.operation.interact.lost_void_artifact_pos import LostVoidArtifactPos
 from zzz_od.application.hollow_zero.lost_void.operation.lost_void_move_by_det import MoveTargetWrapper
@@ -33,12 +33,12 @@ class LostVoidContext:
     def __init__(self, ctx: ZContext):
         self.ctx: ZContext = ctx
 
-        self.detector: Optional[LostVoidDetector] = None
-        self.challenge_config: Optional[LostVoidChallengeConfig] = None
+        self.detector: LostVoidDetector | None = None
+        self.challenge_config: LostVoidChallengeConfig | None = None
 
-        self.all_artifact_list: List[LostVoidArtifact] = []  # 武备 + 鸣徽
+        self.all_artifact_list: list[LostVoidArtifact] = []  # 武备 + 鸣徽
         self.gear_by_name: dict[str, LostVoidArtifact] = {}  # key=名称 value=武备
-        self.cate_2_artifact: dict[str, List[LostVoidArtifact]] = {}  # key=分类 value=藏品
+        self.cate_2_artifact: dict[str, list[LostVoidArtifact]] = {}  # key=分类 value=藏品
 
         self.investigation_strategy_list: list[LostVoidInvestigationStrategy] = []  # 调查战略
 
@@ -159,7 +159,7 @@ class LostVoidContext:
         result = screen_utils.find_area(self.ctx, screen, '迷失之地-大世界', '标识-BOSS血条')
         return result == FindAreaResultEnum.TRUE
 
-    def detect_to_go(self, screen: MatLike, screenshot_time: float, ignore_list: Optional[List[str]] = None) -> DetectFrameResult:
+    def detect_to_go(self, screen: MatLike, screenshot_time: float, ignore_list: list[str] | None = None) -> DetectFrameResult:
         """
         识别需要前往的内容
         @param screen: 游戏画面
@@ -235,7 +235,7 @@ class LostVoidContext:
 
             time.sleep(self.ctx.battle_assistant_config.screenshot_interval)
 
-    def get_artifact_by_full_name(self, name_full_str: str) -> Optional[LostVoidArtifact]:
+    def get_artifact_by_full_name(self, name_full_str: str) -> LostVoidArtifact | None:
         """
         根据完整名称 获取对应的藏品 名称需要完全一致
         :param name_full_str: 识别的文本 [类型]名称
@@ -248,7 +248,7 @@ class LostVoidContext:
 
         return None
 
-    def match_artifact_by_ocr_full(self, name_full_str: str) -> Optional[LostVoidArtifact]:
+    def match_artifact_by_ocr_full(self, name_full_str: str) -> LostVoidArtifact | None:
         """
         使用 [类型]名称 的文本匹配 藏品
         :param name_full_str: 识别的文本 [类型]名称
@@ -287,7 +287,7 @@ class LostVoidContext:
                 if str_utils.find_by_lcs(art_name, suffix, percent=0.5):
                     return art
 
-    def check_artifact_priority_input(self, input_str: str) -> Tuple[List[str], str]:
+    def check_artifact_priority_input(self, input_str: str) -> tuple[list[str], str]:
         """
         校验优先级的文本输入
         当前采用“文本驱动”策略：
@@ -308,7 +308,7 @@ class LostVoidContext:
 
         return filter_result_list, ''
 
-    def check_region_type_priority_input(self, input_str: str) -> Tuple[List[str], str]:
+    def check_region_type_priority_input(self, input_str: str) -> tuple[list[str], str]:
         """
         校验优先级的文本输入
         错误的输入会被过滤掉
@@ -368,7 +368,7 @@ class LostVoidContext:
                     continue
 
                 # 找横坐标最接近的藏品
-                closest_artifact_pos: Optional[LostVoidArtifactPos] = None
+                closest_artifact_pos: LostVoidArtifactPos | None = None
                 for artifact_pos in artifact_pos_list:
                     # 标识需要在藏品的右方
                     if not mrl.max.rect.x1 > artifact_pos.rect.center.x:
@@ -400,7 +400,7 @@ class LostVoidContext:
             if title_idx is None or title_idx < 0:
                 continue
             # 找横坐标最接近的藏品
-            closest_artifact_pos: Optional[LostVoidArtifactPos] = None
+            closest_artifact_pos: LostVoidArtifactPos | None = None
             for artifact_pos in artifact_pos_list:
                 # 标题需要在藏品的上方
                 if not mrl.max.rect.y2 < artifact_pos.rect.y1:
@@ -500,7 +500,7 @@ class LostVoidContext:
         merged_candidates.sort(key=lambda i: (i.rect.center.x, i.rect.center.y))
         return merged_candidates
 
-    def _create_artifact_from_ocr_text(self, ocr_text: str) -> Tuple[Optional[LostVoidArtifact], bool]:
+    def _create_artifact_from_ocr_text(self, ocr_text: str) -> tuple[LostVoidArtifact | None, bool]:
         """
         从OCR文本提取候选藏品信息
         :return: (artifact, is_primary_name)
@@ -638,12 +638,12 @@ class LostVoidContext:
         return str_utils.find_by_lcs(item_name, artifact.name, percent=0.6) or str_utils.find_by_lcs(item_name, artifact_pos.ocr_text, percent=0.6)
 
     def get_artifact_by_priority(
-            self, artifact_list: List[LostVoidArtifactPos], choose_num: int,
+            self, artifact_list: list[LostVoidArtifactPos], choose_num: int,
             consider_priority_1: bool = True, consider_priority_2: bool = True,
             consider_not_in_priority: bool = True,
-            ignore_idx_list: Optional[list[int]] = None,
+            ignore_idx_list: list[int] | None = None,
             consider_priority_new: bool = False,
-    ) -> List[LostVoidArtifactPos]:
+    ) -> list[LostVoidArtifactPos]:
         """
         根据优先级 返回需要选择的藏品
         :param artifact_list: 识别到的藏品结果
@@ -693,7 +693,7 @@ class LostVoidContext:
         log.debug(f'优先级规则 第一优先级={p1_text}')
         log.debug(f'优先级规则 第二优先级={p2_text}')
 
-        priority_idx_list: List[int] = []  # 优先级排序的下标
+        priority_idx_list: list[int] = []  # 优先级排序的下标
         choose_reason_map: dict[int, str] = {}
         ignored_idx_set = set(ignore_idx_list) if ignore_idx_list is not None else set()
         all_idx_list = [i for i in range(len(artifact_list)) if i not in ignored_idx_set]
@@ -750,7 +750,7 @@ class LostVoidContext:
                         continue
                     add_idx_if_absent(idx, f'{group_name}-非优先级补位')
 
-        result_list: List[LostVoidArtifactPos] = []
+        result_list: list[LostVoidArtifactPos] = []
         for i in range(choose_num):
             if i >= len(priority_idx_list):
                 continue
@@ -770,7 +770,7 @@ class LostVoidContext:
 
         return result_list
 
-    def remove_overlapping_artifacts(self, artifact_list: List[LostVoidArtifactPos]) -> List[LostVoidArtifactPos]:
+    def remove_overlapping_artifacts(self, artifact_list: list[LostVoidArtifactPos]) -> list[LostVoidArtifactPos]:
         """
         去掉横坐标太近的藏品，保留y坐标较小的（位置较高的）
 
@@ -815,7 +815,7 @@ class LostVoidContext:
 
         return result
 
-    def get_entry_by_priority(self, entry_list: List[MoveTargetWrapper]) -> Optional[MoveTargetWrapper]:
+    def get_entry_by_priority(self, entry_list: list[MoveTargetWrapper]) -> MoveTargetWrapper | None:
         """
         根据优先级 返回一个前往的入口
         多个相同入口时选择最右 (因为丢失寻找目标的时候是往左转找)
@@ -826,7 +826,7 @@ class LostVoidContext:
             return None
 
         for priority in self.challenge_config.region_type_priority:
-            target: Optional[MoveTargetWrapper] = None
+            target: MoveTargetWrapper | None = None
 
             for entry in entry_list:
                 for target_name in entry.target_name_list:
@@ -839,7 +839,7 @@ class LostVoidContext:
             if target is not None:
                 return target
 
-        target: Optional[MoveTargetWrapper] = None
+        target: MoveTargetWrapper | None = None
         for entry in entry_list:
             if target is None or entry.entire_rect.x1 > target.entire_rect.x1:
                 target = entry

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
@@ -102,7 +102,8 @@ class LostVoidMoveByDet(ZOperation):
         target_type: str,
         stop_when_interact: bool = True,
         stop_when_disappear: bool = True,
-        ignore_entry_list: Optional[List[str]] = None
+        ignore_entry_list: Optional[List[str]] = None,
+        allow_arrival_by_interact_btn: bool = False,
     ):
         """
         朝识别目标移动 最终返回目标图标 data=LostVoidRegionType.label
@@ -112,6 +113,7 @@ class LostVoidMoveByDet(ZOperation):
         @param stop_when_interact:
         @param stop_when_disappear:
         @param ignore_entry_list:
+        @param allow_arrival_by_interact_btn: 是否允许仅凭交互按钮出现就判定到位
         """
         ZOperation.__init__(
             self,
@@ -125,6 +127,7 @@ class LostVoidMoveByDet(ZOperation):
         self.stop_when_interact: bool = stop_when_interact  # 可交互时停止移动
         self.stop_when_disappear: bool = stop_when_disappear  # 目标消失时停止移动
         self.ignore_entry_list: List[str] = ignore_entry_list
+        self.allow_arrival_by_interact_btn: bool = allow_arrival_by_interact_btn
 
         # 需要按方向选的时候 按最大x值选
         # 入口时 从右往左选可以上楼梯
@@ -511,6 +514,9 @@ class LostVoidMoveByDet(ZOperation):
                     self.ctx.controller.stop_moving_forward()
                     time.sleep(0.5)
             return False
+
+        if self.allow_arrival_by_interact_btn:
+            return True
 
         # 2. 检测图标是否变大
         for result in frame_result.results:

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
@@ -1,7 +1,7 @@
 import time
+from typing import ClassVar
 
 from cv2.typing import MatLike
-from typing import List, Optional, ClassVar
 
 from one_dragon.base.geometry.point import Point
 from one_dragon.base.geometry.rectangle import Rect
@@ -9,13 +9,13 @@ from one_dragon.base.operation.operation_edge import node_from
 from one_dragon.base.operation.operation_node import operation_node
 from one_dragon.base.operation.operation_round_result import OperationRoundResult
 from one_dragon.utils import cal_utils
-from one_dragon.yolo.detect_utils import DetectObjectResult, DetectFrameResult
+from one_dragon.utils.log_utils import log
+from one_dragon.yolo.detect_utils import DetectFrameResult, DetectObjectResult
 from zzz_od.application.hollow_zero.lost_void.context.lost_void_detector import LostVoidDetector
 from zzz_od.application.hollow_zero.lost_void.lost_void_challenge_config import LostVoidRegionType
 from zzz_od.auto_battle import auto_battle_utils
 from zzz_od.context.zzz_context import ZContext
 from zzz_od.operation.zzz_operation import ZOperation
-from one_dragon.utils.log_utils import log
 
 
 class MoveTargetWrapper:
@@ -25,8 +25,8 @@ class MoveTargetWrapper:
         detect_result: DetectObjectResult,
     ):
         self.is_mixed: bool = False  # 是否混合楼层
-        self.target_name_list: List[str] = [detect_result.detect_class.class_name[5:]]
-        self.target_rect_list: List[Rect] = [Rect(detect_result.x1, detect_result.y1, detect_result.x2, detect_result.y2)]
+        self.target_name_list: list[str] = [detect_result.detect_class.class_name[5:]]
+        self.target_rect_list: list[Rect] = [Rect(detect_result.x1, detect_result.y1, detect_result.x2, detect_result.y2)]
 
         self.leftest_target_name: str = self.target_name_list[0]  # 最左边的入口类型 也就是第一个遇到的区域
         self.entire_rect: Rect = self.target_rect_list[0]
@@ -102,7 +102,7 @@ class LostVoidMoveByDet(ZOperation):
         target_type: str,
         stop_when_interact: bool = True,
         stop_when_disappear: bool = True,
-        ignore_entry_list: Optional[List[str]] = None,
+        ignore_entry_list: list[str] | None = None,
         allow_arrival_by_interact_btn: bool = False,
     ):
         """
@@ -126,7 +126,7 @@ class LostVoidMoveByDet(ZOperation):
         self.target_type: str = target_type
         self.stop_when_interact: bool = stop_when_interact  # 可交互时停止移动
         self.stop_when_disappear: bool = stop_when_disappear  # 目标消失时停止移动
-        self.ignore_entry_list: List[str] = ignore_entry_list
+        self.ignore_entry_list: list[str] | None = ignore_entry_list
         self.allow_arrival_by_interact_btn: bool = allow_arrival_by_interact_btn
 
         # 需要按方向选的时候 按最大x值选
@@ -135,8 +135,8 @@ class LostVoidMoveByDet(ZOperation):
             LostVoidRegionType.ENTRY,
         ]
 
-        self.last_target_result: Optional[MoveTargetWrapper] = None  # 最后一次识别到的目标
-        self.last_target_name: Optional[str] = None  # 最后识别到的交互目标名称
+        self.last_target_result: MoveTargetWrapper | None = None  # 最后一次识别到的目标
+        self.last_target_name: str | None = None  # 最后识别到的交互目标名称
         self.same_target_times: int = 0  # 识别到相同目标的次数
         self.stuck_times: int = 0  # 被困次数
         self.total_turn_times: int = 0  # 总共转向次数
@@ -146,7 +146,7 @@ class LostVoidMoveByDet(ZOperation):
         self.lost_target_during_move_times: int = 0  # 移动过程中丢失目标次数
 
         # 转向校准
-        self.last_target_x: Optional[float] = None  # 上一次识别到的目标x轴坐标
+        self.last_target_x: float | None = None  # 上一次识别到的目标x轴坐标
         self.last_actual_turn_distance: int = 0  # 上一次实际的转向距离
         self.estimated_turn_ratio: float = 0.2  # 估算的转向比例
         self.turn_calibration_count: int = 1  # 转向校准次数
@@ -357,7 +357,7 @@ class LostVoidMoveByDet(ZOperation):
         self.last_actual_turn_distance = turn_distance_x
 
         return True
-    def get_move_target(self, frame_result: DetectFrameResult) -> Optional[MoveTargetWrapper]:
+    def get_move_target(self, frame_result: DetectFrameResult) -> MoveTargetWrapper | None:
         """
         获取移动目标
 
@@ -381,14 +381,14 @@ class LostVoidMoveByDet(ZOperation):
 
         return None
 
-    def get_entry_target(self, frame_result: DetectFrameResult) -> Optional[MoveTargetWrapper]:
+    def get_entry_target(self, frame_result: DetectFrameResult) -> MoveTargetWrapper | None:
         """
         获取入口目标 按优先级 尽量避免混合楼层
 
         @param frame_result: 当前帧识别结果
         @return:
         """
-        entry_list: List[MoveTargetWrapper] = []
+        entry_list: list[MoveTargetWrapper] = []
         for result in frame_result.results:
             if result.detect_class.class_name in [LostVoidDetector.CLASS_INTERACT, LostVoidDetector.CLASS_DISTANCE]:
                 continue
@@ -424,7 +424,7 @@ class LostVoidMoveByDet(ZOperation):
         else:
             return None
 
-    def check_stuck(self, new_target: MoveTargetWrapper) -> Optional[OperationRoundResult]:
+    def check_stuck(self, new_target: MoveTargetWrapper) -> OperationRoundResult | None:
         """
         判断是否被困
         @return:
@@ -584,13 +584,13 @@ class LostVoidMoveByDet(ZOperation):
 
         return self.round_success(LostVoidMoveByDet.STATUS_CONTINUE)
 
-    def get_same_as_last_target(self, entry_list: List[MoveTargetWrapper]) -> Optional[MoveTargetWrapper]:
+    def get_same_as_last_target(self, entry_list: list[MoveTargetWrapper]) -> MoveTargetWrapper | None:
         """
         从本次结果中 选择与上一次位置最接近
         @param entry_list:
         @return:
         """
-        nearest_result: Optional[MoveTargetWrapper] = None
+        nearest_result: MoveTargetWrapper | None = None
         for entry in entry_list:
             if len(entry.target_name_list) != len(self.last_target_result.target_name_list):
                 continue

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
@@ -126,6 +126,7 @@ class LostVoidRunLevel(ZOperation):
         self.reward_eval_found: bool = False  # 挑战结果中可以识别到业绩点
         self.reward_dn_found: bool = False  # 挑战结果中可以识别到丁尼
         self.click_challenge_confirm: bool = False  # 点击了挑战确认
+        self.boss_pre_battle: bool = self.region_type == LostVoidRegionType.BOSS  # 终结之役正式开战前的交互阶段
 
         self.had_been_list: List[str] = []  # 已经访问过的类型 1.5更新后 交互后交互类型的图标不会消失 需要自己过滤
 
@@ -212,9 +213,75 @@ class LostVoidRunLevel(ZOperation):
         if self.region_type == LostVoidRegionType.ELITE:
             return self.round_success('战斗区域')
         if self.region_type == LostVoidRegionType.BOSS:
-            return self.round_success('战斗区域')
+            if self.boss_pre_battle:
+                # 终结之役开场可能存在战前对话，先进入非战斗区域处理
+                return self.round_success('非战斗区域')
+            else:
+                return self.round_success('战斗区域')
 
         return self.round_success('非战斗区域')
+
+    def handle_boss_pre_battle(self) -> OperationRoundResult:
+        """
+        终结之役在正式战斗开始前 可能会先出现可交互的蓝色感叹号
+        @return:
+        """
+        if self.ctx.lost_void.is_boss_health_bar_present(self.last_screenshot):
+            self.boss_pre_battle = False
+            self.nothing_times = 0
+            self.last_det_time = self.last_screenshot_time
+            self.last_check_finish_time = self.last_screenshot_time
+            return self.round_success(status='进入战斗')
+
+        result = self.round_by_find_area(self.last_screenshot, '战斗画面', '按键-交互')
+        if result.is_success:
+            self.nothing_times = 0
+            self.interact_target = LostVoidInteractTarget(name='未知', icon='感叹号', is_exclamation=True)
+            return self.round_success(LostVoidDetector.CLASS_INTERACT, wait=0.5)
+
+        frame_result: DetectFrameResult = self.ctx.lost_void.detect_to_go(
+            self.last_screenshot, screenshot_time=self.last_screenshot_time,
+            ignore_list=self.had_been_list)
+        with_interact, _, _ = self.ctx.lost_void.detector.is_frame_with_all(frame_result)
+
+        if with_interact:
+            self.nothing_times = 0
+            op = LostVoidMoveByDet(
+                self.ctx,
+                self.region_type,
+                LostVoidDetector.CLASS_INTERACT,
+                stop_when_disappear=False,
+                allow_arrival_by_interact_btn=True,
+            )
+            op_result = op.execute()
+            if op_result.success:
+                if op_result.status == LostVoidMoveByDet.STATUS_IN_BATTLE:
+                    self.screenshot()
+                    if self.ctx.lost_void.is_boss_health_bar_present(self.last_screenshot):
+                        self.boss_pre_battle = False
+                        self.last_det_time = self.last_screenshot_time
+                        self.last_check_finish_time = self.last_screenshot_time
+                        return self.round_success('进入战斗')
+                    return self.round_wait('等待BOSS血条', wait=0.2)
+                elif op_result.status == LostVoidMoveByDet.STATUS_INTERACT:
+                    self.interact_target = LostVoidInteractTarget(name='未知', icon='感叹号', is_exclamation=True)
+                    return self.round_success('未在大世界')
+                else:
+                    self.interact_target = LostVoidInteractTarget(name='感叹号', icon='感叹号', is_exclamation=True)
+                    return self.round_success(LostVoidDetector.CLASS_INTERACT, wait=1)
+            elif op_result.status == Operation.STATUS_TIMEOUT:
+                return self.round_fail(Operation.STATUS_TIMEOUT)
+            else:
+                return self.round_retry('移动失败')
+
+        self.ctx.controller.turn_by_distance(-200)
+        self.nothing_times += 1
+
+        if self.nothing_times >= 50:
+            self.nothing_times = 0
+            return self.round_fail('处理寻路失败')
+
+        return self.round_wait(status='转动识别目标')
 
     @node_from(from_name='区域类型初始化', status='非战斗区域')
     @node_from(from_name='非战斗画面识别', status=LostVoidDetector.CLASS_DISTANCE)  # 朝白点移动后重新循环
@@ -244,6 +311,9 @@ class LostVoidRunLevel(ZOperation):
         # 在这里判断是因为需要确保在大世界画面 可以按到菜单退出按钮 防止卡在事件选择之类的地方
         if self.last_screenshot_time - self.operation_start_time >= 600:  # 10分钟超时
             return self.round_fail(Operation.STATUS_TIMEOUT)
+
+        if self.boss_pre_battle:
+            return self.handle_boss_pre_battle()
 
         # 在大世界 开始检测
         frame_result: DetectFrameResult = self.ctx.lost_void.detect_to_go(
@@ -325,7 +395,7 @@ class LostVoidRunLevel(ZOperation):
 
         if self.nothing_times >= 50:
             self.nothing_times = 0
-            return self.round_success('处理寻路失败')
+            return self.round_fail('处理寻路失败')
 
         # 识别不到目标的时候 判断是否在战斗 转动等待的时候持续识别 否则0.5秒才识别一次间隔太久 很难识别到黄光
         in_battle = self.ctx.lost_void.check_battle_encounter_in_period(0.5)
@@ -598,7 +668,10 @@ class LostVoidRunLevel(ZOperation):
             log.info('交互后处理 上次交互对象为 %s %s', self.interact_target.icon, self.interact_target.name)
 
         if self.ctx.lost_void.in_normal_world(self.last_screenshot):
-            self.move_after_interact()
+            if not (self.boss_pre_battle
+                    and self.interact_target is not None
+                    and not self.interact_target.after_battle):
+                self.move_after_interact()
             return self.round_success(status='大世界', wait=1)
 
         result = self.round_by_find_area(self.last_screenshot, '迷失之地-挑战结果', '标题-挑战结果')

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
@@ -202,12 +202,7 @@ class LostVoidRunLevel(ZOperation):
         return self.round_success('非战斗区域')
 
     def enter_battle(self, screenshot_time: float | None = None, end_boss_pre_battle: bool = False) -> OperationRoundResult:
-        """
-        更新进入战斗后的公共状态
-        @param screenshot_time: 进入战斗时使用的截图时间
-        @param end_boss_pre_battle: 是否结束终结之役战前阶段
-        @return:
-        """
+        """更新进入战斗后的公共状态。"""
         if end_boss_pre_battle:
             self.boss_pre_battle = False
 
@@ -219,73 +214,9 @@ class LostVoidRunLevel(ZOperation):
         return self.round_success(status='进入战斗')
 
     def is_boss_battle_started(self) -> bool:
-        """
-        判断终结之役是否已经正式进入战斗
-        @return:
-        """
-        if self.ctx.lost_void.is_boss_health_bar_present(self.last_screenshot):
-            return True
-
-        return self.ctx.lost_void.check_battle_encounter(self.last_screenshot, self.last_screenshot_time)
-
-    def handle_boss_pre_battle(self) -> OperationRoundResult:
-        """
-        终结之役在正式战斗开始前 可能会先出现可交互的蓝色感叹号
-        @return:
-        """
-        if self.is_boss_battle_started():
-            return self.enter_battle(end_boss_pre_battle=True)
-
-        result = self.round_by_find_area(self.last_screenshot, '战斗画面', '按键-交互')
-        if result.is_success:
-            self.nothing_times = 0
-            self.interact_target = LostVoidInteractTarget(name='未知', icon='感叹号', is_exclamation=True)
-            return self.round_success(LostVoidDetector.CLASS_INTERACT, wait=0.5)
-
-        frame_result: DetectFrameResult = self.ctx.lost_void.detect_to_go(
-            self.last_screenshot, screenshot_time=self.last_screenshot_time,
-            ignore_list=self.had_been_list)
-        with_interact, _, _ = self.ctx.lost_void.detector.is_frame_with_all(frame_result)
-
-        if with_interact:
-            self.nothing_times = 0
-            op = LostVoidMoveByDet(
-                self.ctx,
-                self.region_type,
-                LostVoidDetector.CLASS_INTERACT,
-                stop_when_disappear=False,
-                allow_arrival_by_interact_btn=True,
-            )
-            op_result = op.execute()
-            if op_result.success:
-                if op_result.status == LostVoidMoveByDet.STATUS_IN_BATTLE:
-                    self.screenshot()
-                    if self.is_boss_battle_started():
-                        return self.enter_battle(end_boss_pre_battle=True)
-                    return self.round_wait('等待BOSS进入战斗', wait=0.2)
-                elif op_result.status == LostVoidMoveByDet.STATUS_INTERACT:
-                    self.interact_target = LostVoidInteractTarget(name='未知', icon='感叹号', is_exclamation=True)
-                    return self.round_success('未在大世界')
-                else:
-                    self.interact_target = LostVoidInteractTarget(name='感叹号', icon='感叹号', is_exclamation=True)
-                    return self.round_success(LostVoidDetector.CLASS_INTERACT, wait=1)
-            elif op_result.status == Operation.STATUS_TIMEOUT:
-                return self.round_fail(Operation.STATUS_TIMEOUT)
-            else:
-                return self.round_retry('移动失败')
-
-        self.ctx.controller.turn_by_distance(-200)
-        self.nothing_times += 1
-
-        if self.nothing_times >= 50:
-            self.nothing_times = 0
-            return self.round_fail('处理寻路失败')
-
-        in_battle = self.ctx.lost_void.check_battle_encounter_in_period(0.5)
-        if in_battle:
-            return self.enter_battle(screenshot_time=time.time(), end_boss_pre_battle=True)
-
-        return self.round_wait(status='转动识别目标')
+        """判断终结之役是否已正式进入战斗。"""
+        return (self.ctx.lost_void.is_boss_health_bar_present(self.last_screenshot)
+                or self.ctx.lost_void.check_battle_encounter(self.last_screenshot, self.last_screenshot_time))
 
     @node_from(from_name='区域类型初始化', status='非战斗区域')
     @node_from(from_name='非战斗画面识别', status=LostVoidDetector.CLASS_DISTANCE)  # 朝白点移动后重新循环
@@ -317,7 +248,14 @@ class LostVoidRunLevel(ZOperation):
             return self.round_fail(Operation.STATUS_TIMEOUT)
 
         if self.boss_pre_battle:
-            return self.handle_boss_pre_battle()
+            if self.is_boss_battle_started():
+                return self.enter_battle(end_boss_pre_battle=True)
+
+            result = self.round_by_find_area(self.last_screenshot, '战斗画面', '按键-交互')
+            if result.is_success:
+                self.nothing_times = 0
+                self.interact_target = LostVoidInteractTarget(name='未知', icon='感叹号', is_exclamation=True)
+                return self.round_success(LostVoidDetector.CLASS_INTERACT, wait=0.5)
 
         # 在大世界 开始检测
         frame_result: DetectFrameResult = self.ctx.lost_void.detect_to_go(
@@ -329,10 +267,16 @@ class LostVoidRunLevel(ZOperation):
         if with_interact:
             self.nothing_times = 0
             op = LostVoidMoveByDet(self.ctx, self.region_type, LostVoidDetector.CLASS_INTERACT,
-                                   stop_when_disappear=False)
+                                   stop_when_disappear=False,
+                                   allow_arrival_by_interact_btn=self.boss_pre_battle)
             op_result = op.execute()
             if op_result.success:
                 if op_result.status == LostVoidMoveByDet.STATUS_IN_BATTLE:
+                    if self.boss_pre_battle:
+                        self.screenshot()
+                        if self.is_boss_battle_started():
+                            return self.enter_battle(end_boss_pre_battle=True)
+                        return self.round_wait('等待BOSS进入战斗', wait=0.2)
                     self.interact_target = LostVoidInteractTarget(name='战斗后', icon='战斗后', after_battle=True)
                     return self.round_success(LostVoidMoveByDet.STATUS_IN_BATTLE)
                 elif op_result.status == LostVoidMoveByDet.STATUS_INTERACT:
@@ -347,7 +291,7 @@ class LostVoidRunLevel(ZOperation):
                 return self.round_retry('移动失败')
 
         # 处理白点移动
-        if with_distance:
+        if with_distance and not self.boss_pre_battle:
             self.nothing_times = 0
             op = LostVoidMoveByDet(self.ctx, self.region_type, LostVoidDetector.CLASS_DISTANCE,
                                    stop_when_interact=False)
@@ -368,11 +312,11 @@ class LostVoidRunLevel(ZOperation):
                 return self.round_retry('移动失败')
 
         # 在转动视角之前，检查是否需要更新优先级
-        if not self.ctx.lost_void.priority_updated:
+        if not self.boss_pre_battle and not self.ctx.lost_void.priority_updated:
             return self.round_success('需要更新优先级')
 
         # 处理下层入口
-        if with_entry:
+        if with_entry and not self.boss_pre_battle:
             self.nothing_times = 0
             op = LostVoidMoveByDet(self.ctx, self.region_type, LostVoidDetector.CLASS_ENTRY,
                                    stop_when_disappear=False, ignore_entry_list=self.had_been_list)
@@ -399,12 +343,12 @@ class LostVoidRunLevel(ZOperation):
 
         if self.nothing_times >= 50:
             self.nothing_times = 0
-            return self.round_fail('处理寻路失败')
+            return self.round_success('处理寻路失败')
 
         # 识别不到目标的时候 判断是否在战斗 转动等待的时候持续识别 否则0.5秒才识别一次间隔太久 很难识别到黄光
         in_battle = self.ctx.lost_void.check_battle_encounter_in_period(0.5)
         if in_battle:
-            return self.enter_battle(screenshot_time=time.time())
+            return self.enter_battle(screenshot_time=time.time(), end_boss_pre_battle=self.boss_pre_battle)
 
         return self.round_wait(status='转动识别目标')
 
@@ -561,7 +505,7 @@ class LostVoidRunLevel(ZOperation):
             return self.round_wait(status=result.status, wait=1)
 
         # 交互后 可能出现了后续的交互
-        return self.round_retry(status=f'未知画面', wait_round_time=1)
+        return self.round_retry(status='未知画面', wait_round_time=1)
 
     def try_talk(self, screen: MatLike) -> OperationRoundResult | None:
         """
@@ -652,7 +596,7 @@ class LostVoidRunLevel(ZOperation):
 
         result = self.round_by_find_and_click_area(screen, '迷失之地-大世界', '区域-右侧对话图标')
         if result.is_success:
-            return self.round_wait(f'尝试交互选项图标', wait=0.5)
+            return self.round_wait('尝试交互选项图标', wait=0.5)
 
     @node_from(from_name='交互处理', status='迷失之地-大世界')
     @node_from(from_name='交互处理', status='迷失之地-挑战结果')

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
@@ -1,5 +1,5 @@
 import time
-from typing import ClassVar, List, Optional
+from typing import ClassVar
 
 import cv2
 from cv2.typing import MatLike
@@ -16,41 +16,21 @@ from one_dragon.utils.i18_utils import gt
 from one_dragon.utils.log_utils import log
 from one_dragon.yolo.detect_utils import DetectFrameResult
 from zzz_od.application.hollow_zero.lost_void import lost_void_const
-from zzz_od.application.hollow_zero.lost_void.context.lost_void_detector import (
-    LostVoidDetector,
-)
-from zzz_od.application.hollow_zero.lost_void.lost_void_challenge_config import (
-    LostVoidRegionType,
-)
-from zzz_od.application.hollow_zero.lost_void.lost_void_run_record import (
-    LostVoidRunRecord,
-)
-from zzz_od.application.hollow_zero.lost_void.operation.interact.lost_void_bangboo_store import (
-    LostVoidBangbooStore,
-)
-from zzz_od.application.hollow_zero.lost_void.operation.interact.lost_void_choose_common import (
-    LostVoidChooseCommon,
-)
-from zzz_od.application.hollow_zero.lost_void.operation.interact.lost_void_choose_gear import (
-    LostVoidChooseGear,
-)
+from zzz_od.application.hollow_zero.lost_void.context.lost_void_detector import LostVoidDetector
+from zzz_od.application.hollow_zero.lost_void.lost_void_challenge_config import LostVoidRegionType
+from zzz_od.application.hollow_zero.lost_void.lost_void_run_record import LostVoidRunRecord
+from zzz_od.application.hollow_zero.lost_void.operation.interact.lost_void_bangboo_store import LostVoidBangbooStore
+from zzz_od.application.hollow_zero.lost_void.operation.interact.lost_void_choose_common import LostVoidChooseCommon
+from zzz_od.application.hollow_zero.lost_void.operation.interact.lost_void_choose_gear import LostVoidChooseGear
 from zzz_od.application.hollow_zero.lost_void.operation.interact.lost_void_interact_target_const import (
     LostVoidInteractNPC,
     LostVoidInteractTarget,
     match_interact_target,
 )
-from zzz_od.application.hollow_zero.lost_void.operation.interact.lost_void_lottery import (
-    LostVoidLottery,
-)
-from zzz_od.application.hollow_zero.lost_void.operation.interact.lost_void_route_change import (
-    LostVoidRouteChange,
-)
-from zzz_od.application.hollow_zero.lost_void.operation.lost_void_move_by_det import (
-    LostVoidMoveByDet,
-)
-from zzz_od.application.hollow_zero.lost_void.operation.update_priority_operation import (
-    UpdatePriorityOperation,
-)
+from zzz_od.application.hollow_zero.lost_void.operation.interact.lost_void_lottery import LostVoidLottery
+from zzz_od.application.hollow_zero.lost_void.operation.interact.lost_void_route_change import LostVoidRouteChange
+from zzz_od.application.hollow_zero.lost_void.operation.lost_void_move_by_det import LostVoidMoveByDet
+from zzz_od.application.hollow_zero.lost_void.operation.update_priority_operation import UpdatePriorityOperation
 from zzz_od.context.zzz_context import ZContext
 from zzz_od.operation.challenge_mission.exit_in_battle import ExitInBattle
 from zzz_od.operation.challenge_mission.restart_in_battle import RestartInBattle
@@ -105,7 +85,7 @@ class LostVoidRunLevel(ZOperation):
             op_name='迷失之地-层间移动',
             # timeout_seconds=600,  # 不在这里设置超时 而是统一在 '非战斗画面识别' 中处理
         )
-        self.run_record: Optional[LostVoidRunRecord] = self.ctx.run_context.get_run_record(
+        self.run_record: LostVoidRunRecord | None = self.ctx.run_context.get_run_record(
             instance_idx=self.ctx.current_instance_idx,
             app_id=lost_void_const.APP_ID,
         )
@@ -114,7 +94,7 @@ class LostVoidRunLevel(ZOperation):
         self.detector: LostVoidDetector = self.ctx.lost_void.detector
         self.nothing_times: int = 0  # 识别不到内容的次数
         self.find_target_fail_count: int = 0  # 寻路失败次数
-        self.interact_target: Optional[LostVoidInteractTarget] = None  # 最终识别的交互目标 后续改动应该都是用这个判断
+        self.interact_target: LostVoidInteractTarget | None = None  # 最终识别的交互目标 后续改动应该都是用这个判断
         self.interact_attempted: bool = False  # 是否尝试过交互
 
         self.last_frame_in_battle: bool = True  # 上一帧画面在战斗
@@ -128,7 +108,7 @@ class LostVoidRunLevel(ZOperation):
         self.click_challenge_confirm: bool = False  # 点击了挑战确认
         self.boss_pre_battle: bool = self.region_type == LostVoidRegionType.BOSS  # 终结之役正式开战前的交互阶段
 
-        self.had_been_list: List[str] = []  # 已经访问过的类型 1.5更新后 交互后交互类型的图标不会消失 需要自己过滤
+        self.had_been_list: list[str] = []  # 已经访问过的类型 1.5更新后 交互后交互类型的图标不会消失 需要自己过滤
 
     @node_from(from_name='非战斗画面识别', status='未在大世界')  # 有小概率交互入口后 没处理好结束本次RunLevel 重新从等待加载 开始
     @node_from(from_name='非战斗画面识别', status='按钮-挑战-确认')  # 挑战类型的对话框确认后 第一次点击可能无效 跳回来这里点击到最后生效为止
@@ -221,7 +201,7 @@ class LostVoidRunLevel(ZOperation):
 
         return self.round_success('非战斗区域')
 
-    def enter_battle(self, screenshot_time: Optional[float] = None, end_boss_pre_battle: bool = False) -> OperationRoundResult:
+    def enter_battle(self, screenshot_time: float | None = None, end_boss_pre_battle: bool = False) -> OperationRoundResult:
         """
         更新进入战斗后的公共状态
         @param screenshot_time: 进入战斗时使用的截图时间
@@ -519,8 +499,8 @@ class LostVoidRunLevel(ZOperation):
                 '迷失之地-大世界'
             ]
         )
-        interact_op: Optional[ZOperation] = None
-        interact_type: Optional[str] = None
+        interact_op: ZOperation | None = None
+        interact_type: str | None = None
         if screen_name == '迷失之地-武备选择':
             interact_op = LostVoidChooseGear(self.ctx)
         elif screen_name == '迷失之地-通用选择':
@@ -634,7 +614,7 @@ class LostVoidRunLevel(ZOperation):
                 self.ctx.controller.click(area.center)
                 return self.round_wait(f'尝试交互 {str(list(ocr_result_map.keys()))}', wait=0.5)
 
-    def try_talk_options(self, screen: MatLike) -> Optional[OperationRoundResult]:
+    def try_talk_options(self, screen: MatLike) -> OperationRoundResult | None:
         """
         判断是否有对话选项
         @return:

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
@@ -221,17 +221,40 @@ class LostVoidRunLevel(ZOperation):
 
         return self.round_success('非战斗区域')
 
+    def enter_battle(self, screenshot_time: Optional[float] = None, end_boss_pre_battle: bool = False) -> OperationRoundResult:
+        """
+        更新进入战斗后的公共状态
+        @param screenshot_time: 进入战斗时使用的截图时间
+        @param end_boss_pre_battle: 是否结束终结之役战前阶段
+        @return:
+        """
+        if end_boss_pre_battle:
+            self.boss_pre_battle = False
+
+        self.nothing_times = 0
+        current_time = self.last_screenshot_time if screenshot_time is None else screenshot_time
+        self.last_det_time = current_time
+        self.last_check_finish_time = current_time
+
+        return self.round_success(status='进入战斗')
+
+    def is_boss_battle_started(self) -> bool:
+        """
+        判断终结之役是否已经正式进入战斗
+        @return:
+        """
+        if self.ctx.lost_void.is_boss_health_bar_present(self.last_screenshot):
+            return True
+
+        return self.ctx.lost_void.check_battle_encounter(self.last_screenshot, self.last_screenshot_time)
+
     def handle_boss_pre_battle(self) -> OperationRoundResult:
         """
         终结之役在正式战斗开始前 可能会先出现可交互的蓝色感叹号
         @return:
         """
-        if self.ctx.lost_void.is_boss_health_bar_present(self.last_screenshot):
-            self.boss_pre_battle = False
-            self.nothing_times = 0
-            self.last_det_time = self.last_screenshot_time
-            self.last_check_finish_time = self.last_screenshot_time
-            return self.round_success(status='进入战斗')
+        if self.is_boss_battle_started():
+            return self.enter_battle(end_boss_pre_battle=True)
 
         result = self.round_by_find_area(self.last_screenshot, '战斗画面', '按键-交互')
         if result.is_success:
@@ -257,12 +280,9 @@ class LostVoidRunLevel(ZOperation):
             if op_result.success:
                 if op_result.status == LostVoidMoveByDet.STATUS_IN_BATTLE:
                     self.screenshot()
-                    if self.ctx.lost_void.is_boss_health_bar_present(self.last_screenshot):
-                        self.boss_pre_battle = False
-                        self.last_det_time = self.last_screenshot_time
-                        self.last_check_finish_time = self.last_screenshot_time
-                        return self.round_success('进入战斗')
-                    return self.round_wait('等待BOSS血条', wait=0.2)
+                    if self.is_boss_battle_started():
+                        return self.enter_battle(end_boss_pre_battle=True)
+                    return self.round_wait('等待BOSS进入战斗', wait=0.2)
                 elif op_result.status == LostVoidMoveByDet.STATUS_INTERACT:
                     self.interact_target = LostVoidInteractTarget(name='未知', icon='感叹号', is_exclamation=True)
                     return self.round_success('未在大世界')
@@ -280,6 +300,10 @@ class LostVoidRunLevel(ZOperation):
         if self.nothing_times >= 50:
             self.nothing_times = 0
             return self.round_fail('处理寻路失败')
+
+        in_battle = self.ctx.lost_void.check_battle_encounter_in_period(0.5)
+        if in_battle:
+            return self.enter_battle(screenshot_time=time.time(), end_boss_pre_battle=True)
 
         return self.round_wait(status='转动识别目标')
 
@@ -400,9 +424,7 @@ class LostVoidRunLevel(ZOperation):
         # 识别不到目标的时候 判断是否在战斗 转动等待的时候持续识别 否则0.5秒才识别一次间隔太久 很难识别到黄光
         in_battle = self.ctx.lost_void.check_battle_encounter_in_period(0.5)
         if in_battle:
-            self.last_det_time = time.time()
-            self.last_check_finish_time = time.time()
-            return self.round_success(status='进入战斗')
+            return self.enter_battle(screenshot_time=time.time())
 
         return self.round_wait(status='转动识别目标')
 


### PR DESCRIPTION
fix #2178 


https://github.com/OneDragon-Anything/ZenlessZoneZero-OneDragon/blob/main/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
从当前代码看，开场直接按“战斗区域”处理的只有这几类：

战斗-道中危机，也就是 ELITE（中场小boss），见 lost_void_challenge_config.py (line 28) 和 lost_void_run_level.py (line 212)
战斗-终结之役，也就是 BOSS（最终大boss），见 lost_void_challenge_config.py (line 29) 和 lost_void_run_level.py (line 214)
挑战-限时，但只有点过挑战确认后才归到“战斗区域”，见 lost_void_run_level.py (line 190)

-----

[PLAN.md](https://github.com/user-attachments/files/26672024/PLAN.md)

-----
- BOSS关：
   - 一般一进去就是战斗状态
   - 可能会有战前对话，没有白点指引，由于boss体型太大导致角色刚靠近感叹号就会消失，但是交互键会出现（参考：魔神黄金邦布）
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/fe105096-4227-4c44-8c39-9f86996019db" />

<img width="1920" height="1080" alt="0c60596e3a23a5faf7820aa4e09ca369" src="https://github.com/user-attachments/assets/d082fe30-26ab-45b1-8d08-67e4e53dd266" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/95f13704-6e67-458d-b9f4-d54ff255542f" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2ed36788-739c-40f9-96ea-123dfb18c95b" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/dca961ac-6af2-418e-be4d-ea50bfe4df71" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 添加了BOSS血条识别功能，支持在战斗中准确检测BOSS生命值条
  * 实现了BOSS战前阶段检测和处理机制，优化了BOSS战斗前的导航流程
  * 增强了交互按钮到达目标的逻辑，提升了战斗前期的交互稳定性

* **Refactor**
  * 更新了代码类型注解，采用Python 3.10+现代语法标准
<!-- end of auto-generated comment: release notes by coderabbit.ai -->