### PR TITLE
fix: replace 9 bare excepts with except Exception

### DIFF
--- a/service/zzz_data_model.py
+++ b/service/zzz_data_model.py
@@ -32,7 +32,7 @@ def get_db_session():
 def get_battle_info():
     try:
         return session.query(BattleInfo).order_by(BattleInfo.creation_date.desc()).all()
-    except:
+    except Exception:
         session.rollback()
     finally:
         session.close()
@@ -41,7 +41,7 @@ def get_battle_info():
 def get_battle_url(bid):
     try:
         return session.query(BattleInfo).filter_by(id=bid).first()
-    except:
+    except Exception:
         session.rollback()
     finally:
         session.close()
@@ -50,7 +50,7 @@ def get_battle_url(bid):
 def get_battle_by_name(battle_name):
     try:
         return session.query(BattleInfo).filter_by(battle_name=battle_name).first()
-    except:
+    except Exception:
         session.rollback()
     finally:
         session.close()

--- a/service/zzz_save_battle_class.py
+++ b/service/zzz_save_battle_class.py
@@ -68,7 +68,7 @@ async def save_battle(battle_name: str, file, creation_name: str, creation_date:
             )
             session.add(new_battle)
             session.commit()
-    except:
+    except Exception:
         session.rollback()
         raise  # 可以选择抛出异常，以便调用者可以捕捉到错误
     finally:

--- a/src/one_dragon/utils/i18_utils.py
+++ b/src/one_dragon/utils/i18_utils.py
@@ -17,7 +17,7 @@ def detect_language():
             return 'zh'
         else:
             return 'en'
-    except:
+    except Exception:
         return 'zh'
 
 

--- a/src/one_dragon_qt/app/devtools/image_matting_interface.py
+++ b/src/one_dragon_qt/app/devtools/image_matting_interface.py
@@ -340,7 +340,7 @@ class ImageMattingInterface(VerticalScrollInterface):
                     return None
             
             return rgb
-        except:
+        except Exception:
             return None
 
     def _auto_crop_to_valid_area(self):

--- a/src/onnxocr/operators.py
+++ b/src/onnxocr/operators.py
@@ -130,7 +130,7 @@ class DetResizeForTest(object):
             if int(resize_w) <= 0 or int(resize_h) <= 0:
                 return None, (None, None)
             img = cv2.resize(img, (int(resize_w), int(resize_h)))
-        except:
+        except Exception:
             print(img.shape, resize_w, resize_h)
             sys.exit(0)
         ratio_h = resize_h / float(h)

--- a/src/onnxocr/rec_postprocess.py
+++ b/src/onnxocr/rec_postprocess.py
@@ -688,7 +688,7 @@ class NRTRLabelDecode(BaseRecLabelDecode):
             for idx in range(len(text_index[batch_idx])):
                 try:
                     char_idx = self.character[int(text_index[batch_idx][idx])]
-                except:
+                except Exception:
                     continue
                 if char_idx == "</s>":  # end
                     break

--- a/tools/ci/update_contributors.py
+++ b/tools/ci/update_contributors.py
@@ -54,7 +54,7 @@ def http_get(url: str, headers: Optional[dict] = None, retries: int = 5, backoff
                     error_content = e.read().decode()
                     if 'rate limit' in error_content.lower():
                         print("提示: 设置 GITHUB_TOKEN 环境变量可以提高速率限制")
-                except:
+                except Exception:
                     pass  # 忽略读取错误内容的异常
 
             # 对于5xx错误和403错误进行重试（403可能是速率限制）


### PR DESCRIPTION
Replace 9 bare `except:` with `except Exception:` across 7 files. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **重构**
  * 优化了多个模块中的异常处理机制，用更具体的异常类型替代了宽泛的异常捕获。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->