### PR TITLE
ci: 调整Mirror酱上传逻辑

### DIFF
--- a/.github/workflows/mirrorchyan_uploading.yml
+++ b/.github/workflows/mirrorchyan_uploading.yml
@@ -14,11 +14,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [x86_64, aarch64]
         include:
           - arch: x86_64
             type: WithRuntime
-          - arch: aarch64
+          - arch: ''
             type: Full-Environment
     steps:
       - uses: MirrorChyan/uploading-action@v1


### PR DESCRIPTION
Removed aarch64 architecture from the build matrix and added an empty architecture entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- 更新了构建流程的架构配置设置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->