### PR TITLE
[矩阵行动] 协战 - 识别不到 'up' 时点击第一个角色

### DIFF
--- a/src/zzz_od/application/hollow_zero/lost_void/lost_void_app.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/lost_void_app.py
@@ -512,7 +512,8 @@ class LostVoidApp(ZApplication):
                 offset_x, offset_y = no_level_context.crop_offset
                 click_pos = Point(center_x + offset_x, center_y + offset_y)
                 log.debug(
-                    f"【追新模式】 找到无等级战略，点击坐标: {click_pos} (相对: ({center_x}, {center_y}), 偏移: {no_level_context.crop_offset})")
+                    f"【追新模式】 找到无等级战略，点击坐标: {click_pos} (相对: ({center_x}, {center_y}), 偏移: {no_level_context.crop_offset})"
+                )
                 self.ctx.controller.click(click_pos)
                 time.sleep(1)
                 return self._click_confirm_after_strategy_chosen()
@@ -563,7 +564,9 @@ class LostVoidApp(ZApplication):
                 center_y = int(M["m01"] / M["m00"])
                 offset_x, offset_y = frame_context.crop_offset
                 click_pos = Point(center_x + offset_x, center_y + offset_y)
-                log.debug(f"【追新模式】 点击目标坐标: {click_pos} (相对: ({center_x}, {center_y}), 偏移: {frame_context.crop_offset})")
+                log.debug(
+                    f"【追新模式】 点击目标坐标: {click_pos} (相对: ({center_x}, {center_y}), 偏移: {frame_context.crop_offset})"
+                )
                 self.ctx.controller.click(click_pos)
                 time.sleep(1)
                 return self._click_confirm_after_strategy_chosen()


### PR DESCRIPTION
不知道为何, 我这边薇薇安的up识别不到, 如果大家能识别到就忽略这个pr吧
另外雨果头上的冰元素会被识别为五角星, 所以ocr队列的第一个一定是雨果

<img width="1920" height="1080" alt="_1773031949112" src="https://github.com/user-attachments/assets/859eefc4-b394-4066-8942-09ca321236cd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes（错误修复）**
  * 优化了协战代理选择流程：改为更确定性的优先匹配策略（优先精确匹配其一标识，其次备用标识），统一单点执行点击，并在未找到时使用更长的重试等待与提示以提高稳定性与成功率。

* **Refactor（重构）**
  * 调整了日志输出格式和条件表达式可读性，提升代码可维护性（不改变外部行为）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->