### PR TITLE
fix(charge): 储蓄电量不足时应直接失败而非使用全部电量

### DIFF
--- a/src/zzz_od/operation/restore_charge.py
+++ b/src/zzz_od/operation/restore_charge.py
@@ -173,7 +173,7 @@ class RestoreCharge(ZOperation):
             return self.round_retry('恢复电量失败', wait=0.5)
 
 
-def __debug_charge():
+def __debug_charge() -> None:
     ctx = ZContext()
     ctx.init()
     ctx.init_ocr()
@@ -188,7 +188,7 @@ def __debug_charge():
     cv2_utils.show_image(part, wait=0)
     print(ocr_result)
 
-def __debug():
+def __debug() -> None:
     ctx = ZContext()
     ctx.init()
     ctx.init_ocr()


### PR DESCRIPTION
## 问题描述
当前储蓄电量恢复流程中，当所需电量大于现有储蓄电量时，
代码仍会进入处理节点并使用全部可用电量继续执行。
这不符合预期行为：电量不足时应直接失败，
由上层应用决定是否跳过当前计划。

## 修改内容
1. 在 `set_charge_amount` 中增加储蓄电量不足检查
   - 电量不足时直接返回失败，不进入处理节点
2. 在 `handle_backup_charge` 中添加防御性检查

## 行为变化
- 修改前：储蓄电量不足时，使用全部剩余电量继续
- 修改后：储蓄电量不足时，直接失败，由 ChargePlanApp 决定处理方式

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 强化确认按钮交互：改为更可靠的确认识别方式，找不到或点击确认失败时会立即返回明确重试提示，避免继续执行后续步骤。
  * 优化充能验证：在使用备用充能来源且当前电量不足时会给出明确错误并阻止继续操作，减少无效流程。
  * 新增失败处理分支：在识别或电量异常时会触发专门的失败节点并返回明确失败信息。

* **Chores**
  * 改进调试与初始化流程以提升稳定性与可预测性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->