### PR TITLE
fix:通知附带图片功能

### DIFF
--- a/src/one_dragon/base/operation/application_base.py
+++ b/src/one_dragon/base/operation/application_base.py
@@ -81,7 +81,7 @@ class Application(Operation):
         self._update_record_after_stop(result)
 
         if self.ctx.run_context.is_app_need_notify(self.app_id):
-            send_application_notify(self, result.success)
+            send_application_notify(self, result.success, image=self.push_screenshot)
 
         self.ctx.dispatch_event(ApplicationEventId.APPLICATION_STOP.value, self.app_id)
 

--- a/src/one_dragon/base/operation/operation.py
+++ b/src/one_dragon/base/operation/operation.py
@@ -174,6 +174,9 @@ class Operation(OperationBase):
         self.node_retry_times: int = 0
         """当前节点的重试次数"""
 
+        self.push_screenshot: np.ndarray | None = None
+        """用于消息推送的截图, 不一定是最后一个节点的截图"""
+
         self.last_screenshot: np.ndarray | None = None
         """上一次的截图 用于出错时保存"""
 
@@ -206,6 +209,7 @@ class Operation(OperationBase):
         self.node_clicked = False
         self._current_node_start_time = now
         self._previous_round_result = None
+        self.push_screenshot = None
         self.node_status.clear()
 
         # 监听事件
@@ -433,6 +437,7 @@ class Operation(OperationBase):
                 round_result: OperationRoundResult = self.round_retry('异常')
                 if self.last_screenshot is not None:
                     file_name = self.save_screenshot()
+                    self.push_screenshot = self.last_screenshot
                     log.error('%s 执行出错 相关截图保存至 %s', self.display_name, file_name, exc_info=True)
                 else:
                     log.error('%s 执行出错', self.display_name, exc_info=True)

--- a/src/one_dragon/base/operation/operation_notify.py
+++ b/src/one_dragon/base/operation/operation_notify.py
@@ -4,6 +4,8 @@ from collections.abc import Callable
 from enum import Enum
 from typing import TYPE_CHECKING
 
+from cv2.typing import MatLike
+
 from one_dragon.base.config.notify_config import NotifyLevel
 from one_dragon.base.operation.operation_round_result import OperationRoundResult
 from one_dragon.utils.i18_utils import gt
@@ -64,12 +66,13 @@ def _get_notify_level(operation: Operation) -> int:
     return operation.ctx.notify_config.get_app_notify_level(app_id)
 
 
-def send_application_notify(app: Application, status: bool | None) -> None:
+def send_application_notify(app: Application, status: bool | None, image: MatLike | None = None) -> None:
     """向外部推送应用运行状态通知。
 
     Args:
         app: Application 实例
         status: True=成功, False=失败, None=开始
+        image: 图片
     """
     # 验证配置
     if _get_notify_level(app) < NotifyLevel.APP:
@@ -96,6 +99,7 @@ def send_application_notify(app: Application, status: bool | None) -> None:
     app.ctx.push_service.push_async(
         title=app.ctx.notify_config.title,
         content=message,
+        image=image
     )
 
 

--- a/src/one_dragon/base/push/push_service.py
+++ b/src/one_dragon/base/push/push_service.py
@@ -143,6 +143,8 @@ class PushService:
         """
         if not self.push_config.send_image:
             image = None
+        if image is not None:
+            content += '\n (截图如下)'
 
         any_ok: bool = False
         err_msg: str = ''

--- a/src/zzz_od/application/charge_plan/charge_plan_app.py
+++ b/src/zzz_od/application/charge_plan/charge_plan_app.py
@@ -81,6 +81,7 @@ class ChargePlanApp(ZApplication):
         if digit is None:
             return self.round_retry('未识别到电量', wait=1)
 
+        self.push_screenshot = self.last_screenshot
         self.charge_power = digit
         self.run_record.record_current_charge_power(digit)
         return self.round_success(f'剩余电量 {digit}')

--- a/src/zzz_od/application/email_app/email_app.py
+++ b/src/zzz_od/application/email_app/email_app.py
@@ -70,6 +70,7 @@ class EmailApp(ZApplication):
         领取后的确认按钮可以不按 直接点击外层也可以返回
         :return:
         """
+        self.push_screenshot = self.last_screenshot
         return self.round_by_find_and_click_area(self.last_screenshot, '菜单', '返回', success_wait=1, retry_wait=1)
 
     @node_from(from_name='返回菜单')

--- a/src/zzz_od/application/engagement_reward/engagement_reward_app.py
+++ b/src/zzz_od/application/engagement_reward/engagement_reward_app.py
@@ -61,6 +61,7 @@ class EngagementRewardApp(ZApplication):
     @node_notify(when=NotifyTiming.CURRENT_DONE, detail=True)
     @operation_node(name='识别活跃度')
     def check_engagement(self) -> OperationRoundResult:
+        self.push_screenshot = self.last_screenshot
         result = self.round_by_find_area(self.last_screenshot, '快捷手册', '活跃度奖励-4')
         return self.round_success('活跃度已满') if result.is_success else self.round_fail('活跃度未满')
 

--- a/src/zzz_od/application/hollow_zero/lost_void/lost_void_app.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/lost_void_app.py
@@ -861,6 +861,7 @@ class LostVoidApp(ZApplication):
     @node_from(from_name='全部领取', success=False)
     @operation_node(name='完成后返回')
     def back_at_last(self) -> OperationRoundResult:
+        self.push_screenshot = self.last_screenshot
         op = BackToNormalWorld(self.ctx)
         return self.round_by_op_result(op.execute())
 

--- a/src/zzz_od/application/intel_board/intel_board_app.py
+++ b/src/zzz_od/application/intel_board/intel_board_app.py
@@ -328,6 +328,7 @@ class IntelBoardApp(ZApplication):
     @node_notify(when=NotifyTiming.CURRENT_DONE, detail=True)
     @operation_node(name='结束处理')
     def finish_processing(self) -> OperationRoundResult:
+        self.push_screenshot = self.last_screenshot
         status = (f'完成 恶名狩猎: {self.run_record.notorious_hunt_count}, '
                  f'专业挑战室: {self.run_record.expert_challenge_count}, '
                  f'累计经验: {self.run_record.total_exp}')

--- a/src/zzz_od/application/shiyu_defense/shiyu_defense_app.py
+++ b/src/zzz_od/application/shiyu_defense/shiyu_defense_app.py
@@ -358,6 +358,7 @@ class ShiyuDefenseApp(ZApplication):
     @node_from(from_name='多间-战斗失败')
     @operation_node(name='结束后返回')
     def back_after_all(self) -> OperationRoundResult:
+        self.push_screenshot = self.last_screenshot
         log.info('新一期刷新后 可到「式舆防卫战」重置运行记录')
         op = BackToNormalWorld(self.ctx)
         return self.round_by_op_result(op.execute())


### PR DESCRIPTION
通过 self.push_screenshot 来传参
修复并测试了以下场景的通知带图片功能:
- 体力计划
- 邮件
- 每日任务
- 迷失之地
- 情报板 (情报板在通知设置里面没有吗)
- 防卫战

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 应用通知现在可附带截图，通知在出错或关键步骤完成时会包含相关截图以便查看。
  * 若推送包含截图，推送正文会自动添加提示文字“(截图如下)”以便识别。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->