### PR TITLE
refactor(combat_simulation): 重命名卡片选择相关节点，提升代码可读性

### DIFF
--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -1226,6 +1226,20 @@
     template_match_threshold: 0.7
     color_range: null
     goto_list: []
+  - area_name: 内层卡片已选择数量
+    id_mark: false
+    pc_rect:
+    - 752
+    - 130
+    - 770
+    - 150
+    text: ''
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
 - screen_id: commission_assistant
   screen_name: 委托助手
   pc_alt: false

--- a/assets/game_data/screen_info/combat_simulation.yml
+++ b/assets/game_data/screen_info/combat_simulation.yml
@@ -226,3 +226,17 @@ area_list:
   template_match_threshold: 0.7
   color_range: null
   goto_list: []
+- area_name: 内层卡片已选择数量
+  id_mark: false
+  pc_rect:
+  - 752
+  - 130
+  - 770
+  - 150
+  text: ''
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  color_range: null
+  goto_list: []

--- a/src/zzz_od/operation/compendium/combat_simulation.py
+++ b/src/zzz_od/operation/compendium/combat_simulation.py
@@ -198,7 +198,7 @@ class CombatSimulation(ZOperation):
         ocr_result = self.ctx.ocr.run_ocr_single_line(part)
         digit = str_utils.get_positive_digits(ocr_result, None)
         max_card_count = 5
-        if digit is None or digit < 0 or digit > max_card_count:
+        if digit is None or digit > max_card_count:
             return self.round_success(status="未识别到选择数量, 进行基本操作")
 
         plan_card_num = int(self.plan.card_num)

--- a/src/zzz_od/operation/compendium/combat_simulation.py
+++ b/src/zzz_od/operation/compendium/combat_simulation.py
@@ -204,10 +204,8 @@ class CombatSimulation(ZOperation):
             return self.round_success(status="选择数量等于计划设置")
         elif digit < int(self.plan.card_num):
             return self.round_success(status="选择数量小于计划设置", data=int(self.plan.card_num) - digit)
-        elif digit > int(self.plan.card_num):
+        else:
             return self.round_success(status="选择数量大于计划设置", data=digit - int(self.plan.card_num))
-
-        return self.round_retry(result.status, wait=1)
 
     @node_from(from_name='识别已选卡片数量', status='未识别到选择数量, 进行基本操作')
     @operation_node(name='选择数量')

--- a/src/zzz_od/operation/compendium/combat_simulation.py
+++ b/src/zzz_od/operation/compendium/combat_simulation.py
@@ -187,12 +187,31 @@ class CombatSimulation(ZOperation):
                                             success_wait=1, retry_wait=1)
 
     @node_from(from_name='进入选择数量')
-    @operation_node(name='选择数量')
-    def choose_card_num(self) -> OperationRoundResult:
+    @operation_node(name='识别已选卡片数量')
+    def identify_selected_card_count(self) -> OperationRoundResult:
         result = self.round_by_find_area(self.last_screenshot, '实战模拟室', '保存方案')
         if not result.is_success:
             return self.round_retry(result.status, wait=1)
 
+        area = self.ctx.screen_loader.get_area('实战模拟室', '内层卡片已选择数量')
+        part = cv2_utils.crop_image_only(self.last_screenshot, area.rect)
+        ocr_result = self.ctx.ocr.run_ocr_single_line(part)
+        digit = str_utils.get_positive_digits(ocr_result, None)
+        if digit is None:
+            return self.round_success(status="未识别到选择数量, 进行基本操作")
+
+        if digit == int(self.plan.card_num):
+            return self.round_success(status="选择数量等于计划设置")
+        elif digit < int(self.plan.card_num):
+            return self.round_success(status="选择数量小于计划设置", data=int(self.plan.card_num) - digit)
+        elif digit > int(self.plan.card_num):
+            return self.round_success(status="选择数量大于计划设置", data=digit - int(self.plan.card_num))
+
+        return self.round_retry(result.status, wait=1)
+
+    @node_from(from_name='识别已选卡片数量', status='未识别到选择数量, 进行基本操作')
+    @operation_node(name='选择数量')
+    def choose_card_num(self) -> OperationRoundResult:
         for i in range(1, 6):
             log.info('开始取消已选择数量 %d', i)
             self.round_by_click_area('实战模拟室', '内层-已选择卡片1')
@@ -205,8 +224,38 @@ class CombatSimulation(ZOperation):
         return self.round_by_find_and_click_area(self.last_screenshot, '实战模拟室', '保存方案',
                                                  success_wait=2, retry_wait=1)
 
+    @node_from(from_name='识别已选卡片数量', status='选择数量等于计划设置')
+    @operation_node(name='关闭卡片选择界面')
+    def close_card_selection_screen(self) -> OperationRoundResult:
+        return self.round_by_find_and_click_area(self.last_screenshot, '画面-通用', '返回')
+
+    @node_from(from_name='识别已选卡片数量', status='选择数量小于计划设置')
+    @operation_node(name='增加卡片至计划数量')
+    def add_more_cards_to_meet_plan(self) -> OperationRoundResult:
+        for i in range(1, self.previous_node.data + 1):
+            log.info('开始选择数量 %d', i)
+            self.round_by_click_area('实战模拟室', '内层-卡片1')
+            time.sleep(0.5)
+
+        return self.round_by_find_and_click_area(self.last_screenshot, '实战模拟室', '保存方案',
+                                                 success_wait=2, retry_wait=1)
+
+    @node_from(from_name='识别已选卡片数量', status='选择数量大于计划设置')
+    @operation_node(name='移除多余卡片至计划数量')
+    def remove_extra_cards_to_meet_plan(self) -> OperationRoundResult:
+        for i in range(1, self.previous_node.data + 1):
+            log.info('开始取消已选择数量 %d', i)
+            self.round_by_click_area('实战模拟室', '内层-已选择卡片1')
+            time.sleep(0.5)
+
+        return self.round_by_find_and_click_area(self.last_screenshot, '实战模拟室', '保存方案',
+                                                 success_wait=2, retry_wait=1)
+
     @node_from(from_name='进入选择数量', status=CardNumEnum.DEFAULT.value.value)
     @node_from(from_name='选择数量')
+    @node_from(from_name='关闭卡片选择界面')
+    @node_from(from_name='增加卡片至计划数量')
+    @node_from(from_name='移除多余卡片至计划数量')
     @node_from(from_name='恢复电量', status='恢复电量成功')
     @operation_node(name='下一步', node_max_retry_times=10)  # 部分机器加载较慢 延长出战的识别时间
     def click_next(self) -> OperationRoundResult:

--- a/src/zzz_od/operation/compendium/combat_simulation.py
+++ b/src/zzz_od/operation/compendium/combat_simulation.py
@@ -197,15 +197,17 @@ class CombatSimulation(ZOperation):
         part = cv2_utils.crop_image_only(self.last_screenshot, area.rect)
         ocr_result = self.ctx.ocr.run_ocr_single_line(part)
         digit = str_utils.get_positive_digits(ocr_result, None)
-        if digit is None:
+        max_card_count = 5
+        if digit is None or digit < 0 or digit > max_card_count:
             return self.round_success(status="未识别到选择数量, 进行基本操作")
 
-        if digit == int(self.plan.card_num):
+        plan_card_num = int(self.plan.card_num)
+        if digit == plan_card_num:
             return self.round_success(status="选择数量等于计划设置")
-        elif digit < int(self.plan.card_num):
-            return self.round_success(status="选择数量小于计划设置", data=int(self.plan.card_num) - digit)
+        elif digit < plan_card_num:
+            return self.round_success(status="选择数量小于计划设置", data=plan_card_num - digit)
         else:
-            return self.round_success(status="选择数量大于计划设置", data=digit - int(self.plan.card_num))
+            return self.round_success(status="选择数量大于计划设置", data=digit - plan_card_num)
 
     @node_from(from_name='识别已选卡片数量', status='未识别到选择数量, 进行基本操作')
     @operation_node(name='选择数量')


### PR DESCRIPTION
- 将 choose_card_num 重命名为 identify_selected_card_count，并优化状态处理逻辑
- 将原 choose_card_num 拆分为多个独立方法：
  - close_card_selection_screen（数量等于计划时，直接关闭界面）
  - add_more_cards_to_meet_plan（数量小于计划时，增加卡片）
  - remove_extra_cards_to_meet_plan（数量大于计划时，移除多余卡片）
- 保留 choose_card_num 作为未识别到选择数量时的兜底逻辑（重置并重新选择）
- 同步更新所有 @node_from 引用，确保节点流转正确
- 提升卡片选择流程的可读性和可维护性

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 实战模拟室新增视觉检测点“内层卡片已选择数量”，通过 OCR 读取已选数量并据此自动关闭界面、增加或移除卡片以匹配计划。
* **改进**
  * 卡片选择流程更智能：OCR 比较生成多分支结果（等于/少于/多于/未识别），识别失败时回退至原有基本操作流程并继续后续步骤调整。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->