### PR TITLE
fix: 配置跳过计划时不再恢复电池

### DIFF
--- a/src/zzz_od/application/charge_plan/charge_plan_app.py
+++ b/src/zzz_od/application/charge_plan/charge_plan_app.py
@@ -11,6 +11,7 @@ from zzz_od.application.charge_plan.charge_plan_config import (
     CardNumEnum,
     ChargePlanConfig,
     ChargePlanItem,
+    get_charge_plan_config,
 )
 from zzz_od.application.charge_plan.charge_plan_run_record import ChargePlanRunRecord
 from zzz_od.application.zzz_application import ZApplication
@@ -38,11 +39,7 @@ class ChargePlanApp(ZApplication):
             app_id=charge_plan_const.APP_ID,
             op_name=charge_plan_const.APP_NAME,
         )
-        self.config: ChargePlanConfig = self.ctx.run_context.get_config(
-            app_id=charge_plan_const.APP_ID,
-            instance_idx=self.ctx.current_instance_idx,
-            group_id=application_const.DEFAULT_GROUP_ID,
-        )
+        self.config: ChargePlanConfig = get_charge_plan_config(self.ctx)
         self.run_record: ChargePlanRunRecord = self.ctx.run_context.get_run_record(
             app_id=charge_plan_const.APP_ID,
             instance_idx=self.ctx.current_instance_idx,
@@ -126,7 +123,7 @@ class ChargePlanApp(ZApplication):
             # 检查电量是否足够
             if need_charge_power > 0 and self.charge_power < need_charge_power:
                 if (
-                    not self.config.is_restore_charge_enabled
+                    not self.config.should_restore_charge
                     or (self.node_status.get('恢复电量') and self.node_status.get('恢复电量').is_fail)
                 ):
                     if not self.config.skip_plan:

--- a/src/zzz_od/application/charge_plan/charge_plan_config.py
+++ b/src/zzz_od/application/charge_plan/charge_plan_config.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 from one_dragon.base.config.config_item import ConfigItem
 from one_dragon.base.config.yaml_config import YamlConfig
+from one_dragon.base.operation.application import application_const
 from one_dragon.base.operation.application.application_config import ApplicationConfig
 from zzz_od.application.charge_plan import charge_plan_const
 
@@ -318,3 +319,32 @@ class ChargePlanConfig(ApplicationConfig):
     @property
     def is_restore_charge_enabled(self) -> bool:
         return self.restore_charge != RestoreChargeEnum.NONE.value.value
+
+    @property
+    def effective_restore_charge(self) -> str:
+        """
+        电量不足时实际生效的恢复电量方式。
+        """
+        if self.skip_plan:
+            return RestoreChargeEnum.NONE.value.value
+        return self.restore_charge
+
+    @property
+    def should_restore_charge(self) -> bool:
+        """
+        电量不足时是否应该尝试恢复电量。
+        """
+        return self.effective_restore_charge != RestoreChargeEnum.NONE.value.value
+
+
+def get_charge_plan_config(ctx, instance_idx: int | None = None) -> ChargePlanConfig:
+    """
+    获取体力计划配置。
+    """
+    current_instance_idx = ctx.current_instance_idx if instance_idx is None else instance_idx
+    group_id = ctx.run_context.current_group_id or application_const.DEFAULT_GROUP_ID
+    return ctx.run_context.get_config(
+        app_id=charge_plan_const.APP_ID,
+        instance_idx=current_instance_idx,
+        group_id=group_id,
+    )

--- a/src/zzz_od/gui/view/one_dragon/charge_plan_interface.py
+++ b/src/zzz_od/gui/view/one_dragon/charge_plan_interface.py
@@ -311,6 +311,7 @@ class ChargePlanInterface(VerticalScrollInterface, GroupIdMixin):
 
         self.loop_opt = SwitchSettingCard(icon=FluentIcon.SYNC, title='循环执行', content='开启时 会循环执行到体力用尽')
         self.skip_plan_opt = SwitchSettingCard(icon=FluentIcon.FLAG, title='跳过计划', content='开启时 自动跳过体力不足的计划')
+        self.skip_plan_opt.value_changed.connect(self._update_restore_charge_opt_status)
         self.content_widget.add_widget(HorizontalSettingCardGroup([self.loop_opt, self.skip_plan_opt], spacing=6))
 
         self.restore_charge_opt = ComboBoxSettingCard(icon=FluentIcon.ADD_TO, title='恢复电量', options_enum=RestoreChargeEnum)
@@ -364,9 +365,17 @@ class ChargePlanInterface(VerticalScrollInterface, GroupIdMixin):
         self.loop_opt.init_with_adapter(get_prop_adapter(self.config, 'loop'))
         self.skip_plan_opt.init_with_adapter(get_prop_adapter(self.config, 'skip_plan'))
         self.restore_charge_opt.init_with_adapter(get_prop_adapter(self.config, 'restore_charge'))
+        self._update_restore_charge_opt_status(self.config.skip_plan)
 
     def on_interface_hidden(self) -> None:
         VerticalScrollInterface.on_interface_hidden(self)
+
+    def _update_restore_charge_opt_status(self, skip_plan: bool) -> None:
+        self.restore_charge_opt.setDisabled(skip_plan)
+        if skip_plan:
+            self.restore_charge_opt.setContent('已启用跳过计划，运行时视为不使用')
+        else:
+            self.restore_charge_opt.setValue(self.config.restore_charge, emit_signal=False)
 
     def update_plan_list_display(self):
         plan_list = self.config.plan_list

--- a/src/zzz_od/operation/challenge_mission/check_next_after_battle.py
+++ b/src/zzz_od/operation/challenge_mission/check_next_after_battle.py
@@ -1,10 +1,11 @@
-from one_dragon.base.operation.application import application_const
 from one_dragon.base.operation.operation_edge import node_from
 from one_dragon.base.operation.operation_node import operation_node
 from one_dragon.base.operation.operation_round_result import OperationRoundResult
 from one_dragon.utils.i18_utils import gt
-from zzz_od.application.charge_plan import charge_plan_const
-from zzz_od.application.charge_plan.charge_plan_config import ChargePlanConfig
+from zzz_od.application.charge_plan.charge_plan_config import (
+    ChargePlanConfig,
+    get_charge_plan_config,
+)
 from zzz_od.context.zzz_context import ZContext
 from zzz_od.operation.restore_charge import RestoreCharge
 from zzz_od.operation.zzz_operation import ZOperation
@@ -42,13 +43,9 @@ class ChooseNextOrFinishAfterBattle(ZOperation):
             # 没有弹窗，直接返回再来一次的结果
             return self.round_success(status='战斗结果-再来一次')
 
-        config: ChargePlanConfig = self.ctx.run_context.get_config(
-            app_id=charge_plan_const.APP_ID,
-            instance_idx=self.ctx.current_instance_idx,
-            group_id=application_const.DEFAULT_GROUP_ID,
-        )
+        config: ChargePlanConfig = get_charge_plan_config(self.ctx)
 
-        if config.is_restore_charge_enabled:
+        if config.should_restore_charge:
             op = RestoreCharge(self.ctx)
             result = self.round_by_op_result(op.execute())
             self.try_next = result.is_success

--- a/src/zzz_od/operation/compendium/area_patrol.py
+++ b/src/zzz_od/operation/compendium/area_patrol.py
@@ -2,7 +2,6 @@ import time
 from typing import ClassVar
 
 from one_dragon.base.geometry.point import Point
-from one_dragon.base.operation.application import application_const
 from one_dragon.base.operation.operation import Operation
 from one_dragon.base.operation.operation_edge import node_from
 from one_dragon.base.operation.operation_node import operation_node
@@ -10,10 +9,10 @@ from one_dragon.base.operation.operation_notify import node_notify, NotifyTiming
 from one_dragon.base.operation.operation_round_result import OperationRoundResult
 from one_dragon.utils import cv2_utils, str_utils
 from one_dragon.utils.i18_utils import gt
-from zzz_od.application.charge_plan import charge_plan_const
 from zzz_od.application.charge_plan.charge_plan_config import (
     ChargePlanConfig,
     ChargePlanItem,
+    get_charge_plan_config,
 )
 from zzz_od.context.zzz_context import ZContext
 from zzz_od.operation.challenge_mission.check_next_after_battle import (
@@ -46,11 +45,7 @@ class AreaPatrol(ZOperation):
                 gt(plan.mission_type_name, 'game')
             )
         )
-        self.config: ChargePlanConfig = self.ctx.run_context.get_config(
-            app_id=charge_plan_const.APP_ID,
-            instance_idx=self.ctx.current_instance_idx,
-            group_id=application_const.DEFAULT_GROUP_ID,
-        )
+        self.config: ChargePlanConfig = get_charge_plan_config(self.ctx)
 
         self.plan: ChargePlanItem = plan
 
@@ -121,7 +116,7 @@ class AreaPatrol(ZOperation):
     @node_from(from_name='下一步', status=STATUS_CHARGE_NOT_ENOUGH)
     @operation_node(name='恢复电量')
     def restore_charge(self) -> OperationRoundResult:
-        if not self.config.is_restore_charge_enabled:
+        if not self.config.should_restore_charge:
             return self.round_success(AreaPatrol.STATUS_CHARGE_NOT_ENOUGH)
         op = RestoreCharge(self.ctx)
         result = self.round_by_op_result(op.execute())

--- a/src/zzz_od/operation/compendium/combat_simulation.py
+++ b/src/zzz_od/operation/compendium/combat_simulation.py
@@ -2,7 +2,6 @@ import time
 from typing import ClassVar
 
 from one_dragon.base.geometry.point import Point
-from one_dragon.base.operation.application import application_const
 from one_dragon.base.operation.operation import Operation
 from one_dragon.base.operation.operation_edge import node_from
 from one_dragon.base.operation.operation_node import operation_node
@@ -11,11 +10,11 @@ from one_dragon.base.operation.operation_round_result import OperationRoundResul
 from one_dragon.utils import cv2_utils, str_utils
 from one_dragon.utils.i18_utils import gt
 from one_dragon.utils.log_utils import log
-from zzz_od.application.charge_plan import charge_plan_const
 from zzz_od.application.charge_plan.charge_plan_config import (
     CardNumEnum,
     ChargePlanConfig,
     ChargePlanItem,
+    get_charge_plan_config,
 )
 from zzz_od.context.zzz_context import ZContext
 from zzz_od.operation.challenge_mission.check_next_after_battle import (
@@ -50,11 +49,7 @@ class CombatSimulation(ZOperation):
                 gt(plan.mission_name, 'game')
             )
         )
-        self.config: ChargePlanConfig = self.ctx.run_context.get_config(
-            app_id=charge_plan_const.APP_ID,
-            instance_idx=self.ctx.current_instance_idx,
-            group_id=application_const.DEFAULT_GROUP_ID,
-        )
+        self.config: ChargePlanConfig = get_charge_plan_config(self.ctx)
 
         self.plan: ChargePlanItem = plan
         self.scroll_count: int = 0  # 滑动次数计数器
@@ -231,7 +226,7 @@ class CombatSimulation(ZOperation):
     @node_from(from_name='下一步', status=STATUS_CHARGE_NOT_ENOUGH)
     @operation_node(name='恢复电量')
     def restore_charge(self) -> OperationRoundResult:
-        if not self.config.is_restore_charge_enabled:
+        if not self.config.should_restore_charge:
             return self.round_success(CombatSimulation.STATUS_CHARGE_NOT_ENOUGH)
         op = RestoreCharge(self.ctx)
         result = self.round_by_op_result(op.execute())

--- a/src/zzz_od/operation/compendium/expert_challenge.py
+++ b/src/zzz_od/operation/compendium/expert_challenge.py
@@ -14,6 +14,7 @@ from zzz_od.application.charge_plan import charge_plan_const
 from zzz_od.application.charge_plan.charge_plan_config import (
     ChargePlanConfig,
     ChargePlanItem,
+    get_charge_plan_config,
 )
 from zzz_od.auto_battle import auto_battle_utils
 from zzz_od.auto_battle.auto_battle_operator import AutoBattleOperator
@@ -47,11 +48,7 @@ class ExpertChallenge(ZOperation):
                 gt(plan.mission_type_name, 'game')
             )
         )
-        self.config: ChargePlanConfig = self.ctx.run_context.get_config(
-            app_id=charge_plan_const.APP_ID,
-            instance_idx=self.ctx.current_instance_idx,
-            group_id=application_const.DEFAULT_GROUP_ID,
-        )
+        self.config: ChargePlanConfig = get_charge_plan_config(self.ctx)
 
         self.plan: ChargePlanItem = plan
 
@@ -101,7 +98,7 @@ class ExpertChallenge(ZOperation):
     @node_from(from_name='下一步', status=STATUS_CHARGE_NOT_ENOUGH)
     @operation_node(name='恢复电量')
     def restore_charge(self) -> OperationRoundResult:
-        if not self.config.is_restore_charge_enabled:
+        if not self.config.should_restore_charge:
             return self.round_success(ExpertChallenge.STATUS_CHARGE_NOT_ENOUGH)
         op = RestoreCharge(self.ctx)
         result = self.round_by_op_result(op.execute())

--- a/src/zzz_od/operation/compendium/notorious_hunt.py
+++ b/src/zzz_od/operation/compendium/notorious_hunt.py
@@ -11,10 +11,10 @@ from one_dragon.base.operation.operation_round_result import OperationRoundResul
 from one_dragon.utils import cv2_utils, str_utils
 from one_dragon.utils.i18_utils import gt
 from one_dragon.utils.log_utils import log
-from zzz_od.application.charge_plan import charge_plan_const
 from zzz_od.application.charge_plan.charge_plan_config import (
     ChargePlanConfig,
     ChargePlanItem,
+    get_charge_plan_config,
 )
 from zzz_od.application.notorious_hunt import notorious_hunt_const
 from zzz_od.application.notorious_hunt.notorious_hunt_config import (
@@ -58,11 +58,7 @@ class NotoriousHunt(ZOperation):
                 gt(plan.mission_type_name, 'game')
             )
         )
-        self.charge_plan_config: ChargePlanConfig = self.ctx.run_context.get_config(
-            app_id=charge_plan_const.APP_ID,
-            instance_idx=self.ctx.current_instance_idx,
-            group_id=application_const.DEFAULT_GROUP_ID,
-        )
+        self.charge_plan_config: ChargePlanConfig = get_charge_plan_config(self.ctx)
 
         self.config: NotoriousHuntConfig = self.ctx.run_context.get_config(
             app_id=notorious_hunt_const.APP_ID,
@@ -284,7 +280,7 @@ class NotoriousHunt(ZOperation):
     @node_from(from_name='下一步', status=STATUS_CHARGE_NOT_ENOUGH)
     @operation_node(name='恢复电量')
     def restore_charge(self) -> OperationRoundResult:
-        if not self.charge_plan_config.is_restore_charge_enabled:
+        if not self.charge_plan_config.should_restore_charge:
             return self.round_success(NotoriousHunt.STATUS_CHARGE_NOT_ENOUGH)
         op = RestoreCharge(self.ctx)
         result = self.round_by_op_result(op.execute())

--- a/src/zzz_od/operation/restore_charge.py
+++ b/src/zzz_od/operation/restore_charge.py
@@ -2,16 +2,15 @@ import time
 from typing import ClassVar
 
 from one_dragon.base.geometry.point import Point
-from one_dragon.base.operation.application import application_const
 from one_dragon.base.operation.operation_edge import node_from
 from one_dragon.base.operation.operation_node import operation_node
 from one_dragon.base.operation.operation_round_result import OperationRoundResult
 from one_dragon.utils import cv2_utils, str_utils
 from one_dragon.utils.i18_utils import gt
-from zzz_od.application.charge_plan import charge_plan_const
 from zzz_od.application.charge_plan.charge_plan_config import (
     ChargePlanConfig,
     RestoreChargeEnum,
+    get_charge_plan_config,
 )
 from zzz_od.context.zzz_context import ZContext
 from zzz_od.operation.zzz_operation import ZOperation
@@ -40,11 +39,7 @@ class RestoreCharge(ZOperation):
             ctx=ctx,
             op_name='恢复电量'
         )
-        self.config: ChargePlanConfig = self.ctx.run_context.get_config(
-            app_id=charge_plan_const.APP_ID,
-            instance_idx=self.ctx.current_instance_idx,
-            group_id=application_const.DEFAULT_GROUP_ID,
-        )
+        self.config: ChargePlanConfig = get_charge_plan_config(self.ctx)
 
         self.required_charge = required_charge
         self.is_menu = is_menu
@@ -64,12 +59,16 @@ class RestoreCharge(ZOperation):
     @node_from(from_name='打开恢复界面')
     @operation_node(name='选择电量来源')
     def select_charge_source(self) -> OperationRoundResult:
-        if self.config.restore_charge == RestoreChargeEnum.BACKUP_ONLY.value.value:
+        effective_restore_charge = self.config.effective_restore_charge
+
+        if effective_restore_charge == RestoreChargeEnum.BACKUP_ONLY.value.value:
             target_list = [self.SOURCE_BACKUP_CHARGE]
-        elif self.config.restore_charge == RestoreChargeEnum.ETHER_ONLY.value.value:
+        elif effective_restore_charge == RestoreChargeEnum.ETHER_ONLY.value.value:
             target_list = [self.SOURCE_ETHER_BATTERY]
-        elif self.config.restore_charge == RestoreChargeEnum.BOTH.value.value:
+        elif effective_restore_charge == RestoreChargeEnum.BOTH.value.value:
             target_list = [self.SOURCE_BACKUP_CHARGE, self.SOURCE_ETHER_BATTERY]
+        else:
+            return self.round_fail('未启用恢复电量')
 
         target_text_list = [gt(text, 'game') for text in target_list]
         target_area = self.ctx.screen_loader.get_area('恢复电量', '类型')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **功能改进**
  * 优化电量恢复逻辑：当启用"跳过计划"时，"恢复电量"选项将自动禁用，避免配置冲突
  * 改进配置管理：电量恢复的判断机制更加智能，在跳过计划的情况下不会尝试恢复电量

* **重构**
  * 简化配置获取流程，提高代码可维护性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->