### PR TITLE
fix(deploy): 出战提示驱动盘爆仓时跳过该条体力计划

### DIFF
--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -1444,6 +1444,20 @@
     template_match_threshold: 0.7
     color_range: null
     goto_list: []
+  - area_name: 标题-驱动盘数量已达到可拥有上限
+    id_mark: false
+    pc_rect:
+    - 720
+    - 500
+    - 1210
+    - 555
+    text: 驱动盘数量已达到可拥有上限
+    lcs_percent: 0.7
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
 - screen_id: common_screen
   screen_name: 画面-通用
   pc_alt: false

--- a/assets/game_data/screen_info/common_deploy.yml
+++ b/assets/game_data/screen_info/common_deploy.yml
@@ -58,3 +58,17 @@ area_list:
   template_match_threshold: 0.7
   color_range: null
   goto_list: []
+- area_name: 标题-驱动盘数量已达到可拥有上限
+  id_mark: false
+  pc_rect:
+  - 720
+  - 500
+  - 1210
+  - 555
+  text: 驱动盘数量已达到可拥有上限
+  lcs_percent: 0.7
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  color_range: null
+  goto_list: []

--- a/src/zzz_od/operation/deploy.py
+++ b/src/zzz_od/operation/deploy.py
@@ -27,6 +27,10 @@ class Deploy(ZOperation):
     @node_from(from_name='出战')
     @operation_node(name='出战确认')
     def check_level(self) -> OperationRoundResult:
+        result = self.round_by_find_area(self.last_screenshot, '通用-出战', '标题-驱动盘数量已达到可拥有上限')
+        if result.is_success:
+            return self.round_fail('驱动盘数量已达到可拥有上限')
+
         result = self.round_by_find_and_click_area(self.last_screenshot, '通用-出战', '按钮-队员数量少-确认')
         if result.is_success:
             return self.round_wait(result.status, wait=1)
@@ -38,7 +42,7 @@ class Deploy(ZOperation):
         return self.round_retry('无需确认', wait=1)
 
     @node_from(from_name='出战确认')
-    @node_from(from_name='出战确认', success=False)
+    @node_from(from_name='出战确认', success=False, status='无需确认')
     @operation_node(name='进入成功')
     def finish(self) -> OperationRoundResult:
         return self.round_success()
@@ -46,7 +50,7 @@ class Deploy(ZOperation):
 
 def __debug():
     ctx = ZContext()
-    ctx.init_by_config()
+    ctx.init()
     ctx.init_ocr()
     ctx.run_context.start_running()
     op = Deploy(ctx)


### PR DESCRIPTION
fix #2190 

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6d11b905-4ff7-4f04-9049-8e717b3d6b4f" />

目标：`出战` 后出现“驱动盘数量已达到可拥有上限”时，不再把弹窗里的 `确定` 误当成“队员数量少”的继续确认。

行为：识别到该弹窗后，`Deploy` 直接返回失败状态 `驱动盘数量已达到可拥有上限`；体力计划沿用现有失败逻辑，跳过当前计划并继续查找下一条可执行计划。

不做：不点击 `前往拆解`，不点击弹窗 `确定`，不改自动战斗等待逻辑，不扩大到拆解流程。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 新增驱动盘数量上限场景的检测与处理机制，确保在达到可拥有上限时系统能够正确响应

* **优化**
  * 改善部署操作流程中的状态管理逻辑

<!-- end of auto-generated comment: release notes by coderabbit.ai -->