### PR TITLE
feat(notify): 添加"节点失败立即通知"选项

### DIFF
--- a/src/one_dragon/base/config/notify_config.py
+++ b/src/one_dragon/base/config/notify_config.py
@@ -39,6 +39,14 @@ class NotifyConfig(YamlConfig):
     def enable_before_notify(self, new_value: bool) -> None:
         self.update('enable_before_notify', new_value)
 
+    @property
+    def notify_on_error(self) -> bool:
+        return self.get('notify_on_error', True)
+
+    @notify_on_error.setter
+    def notify_on_error(self, new_value: bool) -> None:
+        self.update('notify_on_error', new_value)
+
     def get_app_notify_level(self, app_id: str) -> int:
         """
         获取指定 app_id 的通知等级

--- a/src/one_dragon/base/operation/operation_notify.py
+++ b/src/one_dragon/base/operation/operation_notify.py
@@ -215,9 +215,11 @@ def send_node_notify(
     """
     pool = operation.ctx.run_context.notify_pool
     notify_level = _get_notify_level(operation)
+    is_fail = round_result.is_fail
+    notify_on_error = operation.ctx.notify_config.notify_on_error
 
-    # OFF 等级不处理任何节点通知
-    if notify_level < NotifyLevel.APP:
+    # 节点通知等级 OFF 且 (没有勾选 '节点失败立即通知' 或者 节点没失败)
+    if notify_level < NotifyLevel.APP and not (notify_on_error and is_fail):
         return
     if current_node is None:
         return
@@ -236,15 +238,14 @@ def send_node_notify(
 
     # 合并所有需要处理的通知
     all_notifications: list[NodeNotifyDesc] = []
-    is_success = round_result.is_success
 
     # 收集当前节点的非 PREVIOUS_DONE 通知
     for desc in current_notify_list:
         if desc.when == NotifyTiming.PREVIOUS_DONE:
             continue
-        if desc.when == NotifyTiming.CURRENT_SUCCESS and is_success is not True:
+        if desc.when == NotifyTiming.CURRENT_SUCCESS and is_fail:
             continue
-        if desc.when == NotifyTiming.CURRENT_FAIL and is_success is not False:
+        if desc.when == NotifyTiming.CURRENT_FAIL and not is_fail:
             continue
         all_notifications.append(desc)
 
@@ -278,7 +279,7 @@ def send_node_notify(
     app_name = gt(app_name)
     node_name = gt(current_node.cn)
 
-    result = gt('成功') if is_success else gt('失败')
+    result = gt('失败') if is_fail else gt('成功')
 
     message = (f"{gt('任务')}「{app_name}」"
                f"{gt('节点')}「{node_name}」\n"
@@ -296,8 +297,8 @@ def send_node_notify(
     # 收集到通知池
     pool.add(content=message, image=image)
 
-    # ALL 等级时逐条发送；MERGE 等级时仅收集，但失败时也立即发送
-    if notify_level == NotifyLevel.ALL or (notify_level == NotifyLevel.MERGE and not is_success):
+    # ALL 等级时逐条发送；(勾选 '节点失败立即通知' || MERGE 等级) 时且但失败时也立即发送
+    if notify_level == NotifyLevel.ALL or (is_fail and (notify_on_error or (notify_level == NotifyLevel.MERGE))):
         operation.ctx.push_service.push_async(
             title=operation.ctx.notify_config.title,
             content=message,

--- a/src/one_dragon/base/operation/operation_notify.py
+++ b/src/one_dragon/base/operation/operation_notify.py
@@ -205,7 +205,8 @@ def send_node_notify(
     发送节点级通知，并收集到通知池中。
 
     始终收集消息到通知池中（用于合并通知和最后一张图片）。
-    ALL 等级时逐条立即发送；MERGE 等级时仅收集，但节点失败时也立即发送。
+    ALL 等级时逐条立即发送；MERGE 等级时仅收集。
+    显式开启“节点失败立即通知”且当前节点失败时，额外推送单条通知。
 
     Args:
         operation: Operation 实例
@@ -215,13 +216,12 @@ def send_node_notify(
     """
     pool = operation.ctx.run_context.notify_pool
     notify_level = _get_notify_level(operation)
-    is_fail = round_result.is_fail
+    current_fail = round_result.is_fail
     notify_on_error = operation.ctx.notify_config.notify_on_error
 
-    # 节点通知等级 OFF 且 (没有勾选 '节点失败立即通知' 或者 节点没失败)
-    if notify_level < NotifyLevel.APP and not (notify_on_error and is_fail):
-        return
-    if current_node is None:
+    should_collect_notify = notify_level >= NotifyLevel.APP
+
+    if not should_collect_notify or current_node is None:
         return
 
     # 初始化通知列表
@@ -229,7 +229,7 @@ def send_node_notify(
     next_notify_list: list[NodeNotifyDesc] = []
 
     # 检查当前节点通知列表
-    if current_node is not None and current_node.op_method is not None:
+    if current_node.op_method is not None:
         current_notify_list = getattr(current_node.op_method, 'operation_notify_annotation', [])
 
     # 检查下一节点通知列表
@@ -243,9 +243,9 @@ def send_node_notify(
     for desc in current_notify_list:
         if desc.when == NotifyTiming.PREVIOUS_DONE:
             continue
-        if desc.when == NotifyTiming.CURRENT_SUCCESS and is_fail:
+        if desc.when == NotifyTiming.CURRENT_SUCCESS and current_fail:
             continue
-        if desc.when == NotifyTiming.CURRENT_FAIL and not is_fail:
+        if desc.when == NotifyTiming.CURRENT_FAIL and not current_fail:
             continue
         all_notifications.append(desc)
 
@@ -279,7 +279,7 @@ def send_node_notify(
     app_name = gt(app_name)
     node_name = gt(current_node.cn)
 
-    result = gt('失败') if is_fail else gt('成功')
+    result = gt('失败') if current_fail else gt('成功')
 
     message = (f"{gt('任务')}「{app_name}」"
                f"{gt('节点')}「{node_name}」\n"
@@ -297,8 +297,11 @@ def send_node_notify(
     # 收集到通知池
     pool.add(content=message, image=image)
 
-    # ALL 等级时逐条发送；(勾选 '节点失败立即通知' || MERGE 等级) 时且但失败时也立即发送
-    if notify_level == NotifyLevel.ALL or (is_fail and (notify_on_error or (notify_level == NotifyLevel.MERGE))):
+    should_send_all_nodes = notify_level == NotifyLevel.ALL
+    should_send_fail_notify = current_fail and notify_on_error
+    should_send_now = should_send_all_nodes or should_send_fail_notify
+
+    if should_send_now:
         operation.ctx.push_service.push_async(
             title=operation.ctx.notify_config.title,
             content=message,

--- a/src/one_dragon_qt/widgets/notify_dialog.py
+++ b/src/one_dragon_qt/widgets/notify_dialog.py
@@ -11,6 +11,7 @@ from qfluentwidgets import (
 from one_dragon.base.config.notify_config import NotifyLevel
 from one_dragon.base.operation.one_dragon_context import OneDragonContext
 from one_dragon.utils.i18_utils import gt
+from one_dragon_qt.widgets.horizontal_setting_card_group import HorizontalSettingCardGroup
 
 
 class NotifyDialog(MessageBoxBase):
@@ -32,7 +33,13 @@ class NotifyDialog(MessageBoxBase):
         self.before_notify_switch._onText = gt('开始前通知')
         self.before_notify_switch._offText = gt('开始前通知')
         self.before_notify_switch.label.setText(gt('开始前通知'))
-        self.viewLayout.addWidget(self.before_notify_switch)
+
+        self.notify_on_error_switch = SwitchButton(self)
+        self.notify_on_error_switch.setChecked(self.ctx.notify_config.notify_on_error)
+        self.notify_on_error_switch._onText = gt('节点失败立即通知')
+        self.notify_on_error_switch._offText = gt('节点失败立即通知')
+        self.notify_on_error_switch.label.setText(gt('节点失败立即通知'))
+        self.viewLayout.addWidget(HorizontalSettingCardGroup([self.before_notify_switch, self.notify_on_error_switch], spacing=6))
 
         # 存储所有应用的 ComboBox
         self.app_combos: dict[str, ComboBox] = {}
@@ -84,6 +91,7 @@ class NotifyDialog(MessageBoxBase):
     def accept(self):
         """点击确定时，更新配置"""
         self.ctx.notify_config.enable_before_notify = self.before_notify_switch.isChecked()
+        self.ctx.notify_config.notify_on_error = self.notify_on_error_switch.isChecked()
         for app_id, combo in self.app_combos.items():
             level = combo.currentData()
             setattr(self.ctx.notify_config, app_id, level)

--- a/src/one_dragon_qt/widgets/notify_dialog.py
+++ b/src/one_dragon_qt/widgets/notify_dialog.py
@@ -11,7 +11,9 @@ from qfluentwidgets import (
 from one_dragon.base.config.notify_config import NotifyLevel
 from one_dragon.base.operation.one_dragon_context import OneDragonContext
 from one_dragon.utils.i18_utils import gt
-from one_dragon_qt.widgets.horizontal_setting_card_group import HorizontalSettingCardGroup
+from one_dragon_qt.widgets.horizontal_setting_card_group import (
+    HorizontalSettingCardGroup,
+)
 
 
 class NotifyDialog(MessageBoxBase):

--- a/src/zzz_od/operation/deploy.py
+++ b/src/zzz_od/operation/deploy.py
@@ -1,5 +1,6 @@
 from one_dragon.base.operation.operation_edge import node_from
 from one_dragon.base.operation.operation_node import operation_node
+from one_dragon.base.operation.operation_notify import NotifyTiming, node_notify
 from one_dragon.base.operation.operation_round_result import OperationRoundResult
 from one_dragon.utils.i18_utils import gt
 from zzz_od.context.zzz_context import ZContext
@@ -25,6 +26,7 @@ class Deploy(ZOperation):
         )
 
     @node_from(from_name='出战')
+    @node_notify(when=NotifyTiming.CURRENT_FAIL, detail=True)
     @operation_node(name='出战确认')
     def check_level(self) -> OperationRoundResult:
         result = self.round_by_find_area(self.last_screenshot, '通用-出战', '标题-驱动盘数量已达到可拥有上限')
@@ -39,13 +41,10 @@ class Deploy(ZOperation):
         if result.is_success:
             return self.round_wait(result.status, wait=1)
 
+        if self.node_retry_times == self.node_max_retry_times - 1:
+            # 这里返回成功, 从而不发送失败通知
+            return self.round_success('无需确认', wait=1)
         return self.round_retry('无需确认', wait=1)
-
-    @node_from(from_name='出战确认')
-    @node_from(from_name='出战确认', success=False, status='无需确认')
-    @operation_node(name='进入成功')
-    def finish(self) -> OperationRoundResult:
-        return self.round_success()
 
 
 def __debug():


### PR DESCRIPTION
自测过程：关闭体力计划的单节点通知，开启`节点失败立即通知`，在`\src\zzz_od\operation\deploy.py`中 `check_level`函数第一行添加
```
        return self.round_fail("test")
```
然后运行体力计划。
自测结果：通过
<img width="863" height="1920" alt="{M)F16Q)6XYB7 95%~JGGC7" src="https://github.com/user-attachments/assets/ec2266ac-f193-4ffa-a8ed-bef42f38f175" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“节点失败即时通知”开关，可控制在节点失败时是否立即发送通知。
  * 通知设置对话框新增该开关，和现有通知选项并列管理。

* **行为调整**
  * 出战确认流程的通知行为更新：当开启失败即时通知时会即时发送失败告警；在特定重试场景下避免重复或多余的失败通知。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->