### PR TITLE
feat: 支持通过 Steam 启动游戏

### DIFF
--- a/src/one_dragon/base/config/game_account_config.py
+++ b/src/one_dragon/base/config/game_account_config.py
@@ -71,6 +71,22 @@ class GameAccountConfig(YamlConfig):
         self.update('game_path', new_value)
 
     @property
+    def use_steam(self) -> bool:
+        return self.get('use_steam', False)
+
+    @use_steam.setter
+    def use_steam(self, new_value: bool) -> None:
+        self.update('use_steam', new_value)
+
+    @property
+    def steam_app_id(self) -> str:
+        return self.get('steam_app_id', '4162040')
+
+    @steam_app_id.setter
+    def steam_app_id(self, new_value: str) -> None:
+        self.update('steam_app_id', new_value)
+
+    @property
     def game_language(self) -> str:
         return self.get('game_language', GameLanguageEnum.CN.value.value)
 

--- a/src/one_dragon_qt/view/setting/setting_instance_interface.py
+++ b/src/one_dragon_qt/view/setting/setting_instance_interface.py
@@ -39,6 +39,7 @@ from one_dragon_qt.widgets.setting_card.password_switch_setting_card import (
     PasswordSwitchSettingCard,
 )
 from one_dragon_qt.widgets.setting_card.push_setting_card import PushSettingCard
+from one_dragon_qt.widgets.setting_card.switch_setting_card import SwitchSettingCard
 from one_dragon_qt.widgets.setting_card.text_setting_card import TextSettingCard
 from one_dragon_qt.widgets.vertical_scroll_interface import VerticalScrollInterface
 
@@ -261,6 +262,12 @@ class SettingInstanceInterface(VerticalScrollInterface):
         self.game_password_opt.init_with_adapter(
             self.ctx.game_account_config.get_prop_adapter("password")
         )
+        self.use_steam_opt.init_with_adapter(
+            self.ctx.game_account_config.get_prop_adapter("use_steam")
+        )
+        self.steam_app_id_opt.init_with_adapter(
+            self.ctx.game_account_config.get_prop_adapter("steam_app_id")
+        )
 
     def _get_instanceSwitch_group(self) -> QWidget:
         instance_switch_group = SettingCardGroup(gt("账户列表"))
@@ -325,6 +332,19 @@ class SettingInstanceInterface(VerticalScrollInterface):
             is_password=True,
         )
         instance_settings_group.addSettingCard(self.game_password_opt)
+
+        self.use_steam_opt = SwitchSettingCard(
+            icon=FluentIcon.GAME, title='Steam 启动',
+            content='开启后通过 Steam 启动游戏，需填写下方的 Steam App ID',
+        )
+        instance_settings_group.addSettingCard(self.use_steam_opt)
+
+        self.steam_app_id_opt = TextSettingCard(
+            icon=FluentIcon.TAG,
+            title="Steam App ID",
+            input_placeholder="默认 4162040",
+        )
+        instance_settings_group.addSettingCard(self.steam_app_id_opt)
 
         # self.input_way_opt = ComboBoxSettingCard(icon=FluentIcon.CLIPPING_TOOL, title='输入方式',
         #                                          options_enum=TypeInputWay)

--- a/src/zzz_od/operation/enter_game/open_game.py
+++ b/src/zzz_od/operation/enter_game/open_game.py
@@ -22,11 +22,11 @@ class OpenGame(Operation):
         打开游戏
         :return:
         """
-        if self.ctx.game_account_config.game_path == '':
-            return self.round_fail('未配置游戏路径，请前往 [ 账户管理 ] -> [ 游戏路径 ] 手动设置')
-
         if self.ctx.game_account_config.use_steam:
             return self._open_game_via_steam()
+
+        if self.ctx.game_account_config.game_path == '':
+            return self.round_fail('未配置游戏路径，请前往 [ 账户管理 ] -> [ 游戏路径 ] 手动设置')
 
         full_path = self.ctx.game_account_config.game_path
         dir_path = os.path.dirname(full_path)

--- a/src/zzz_od/operation/enter_game/open_game.py
+++ b/src/zzz_od/operation/enter_game/open_game.py
@@ -24,6 +24,10 @@ class OpenGame(Operation):
         """
         if self.ctx.game_account_config.game_path == '':
             return self.round_fail('未配置游戏路径，请前往 [ 账户管理 ] -> [ 游戏路径 ] 手动设置')
+
+        if self.ctx.game_account_config.use_steam:
+            return self._open_game_via_steam()
+
         full_path = self.ctx.game_account_config.game_path
         dir_path = os.path.dirname(full_path)
         exe_name = os.path.basename(full_path)
@@ -48,4 +52,16 @@ class OpenGame(Operation):
             creationflags=subprocess.CREATE_BREAKAWAY_FROM_JOB
         )
 
+        return self.round_success(wait=5)
+
+    def _open_game_via_steam(self) -> OperationRoundResult:
+        app_id = self.ctx.game_account_config.steam_app_id
+        if app_id == '':
+            return self.round_fail('未配置 Steam App ID，请前往 [ 账户管理 ] 设置')
+
+        log.info('尝试通过 Steam 启动游戏 App ID: %s', app_id)
+        command = f'cmd /c "start "" "steam://rungameid/{app_id}" & exit"'
+        log.info('命令行指令 %s', command)
+
+        subprocess.Popen(command)
         return self.round_success(wait=5)


### PR DESCRIPTION
好像过两个月就上架steam了，默认app id是steam预售页面的。
现在想测试可以把绝区零的exe放进收藏库的非steam游戏，然后加个桌面捷径拿到本地的app id。
之前为了用switch的手柄就一直这样用steam打开的，上架steam之后就直接用steam打开了，先给一条龙加上

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * Steam 启动支持 — 在账户设置中新增“启用 Steam 启动”开关与 Steam App ID 输入，可启用通过 Steam 协议直接启动游戏。
  * 启动流程更新 — 当启用 Steam 启动时，启动操作将使用配置的 App ID 通过系统调用触发 Steam 启动。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->