### PR TITLE
feat: 通知添加“仅错误”层级

### DIFF
--- a/src/one_dragon/base/config/notify_config.py
+++ b/src/one_dragon/base/config/notify_config.py
@@ -51,6 +51,7 @@ class NotifyConfig(YamlConfig):
     def get_app_notify_level(self, app_id: str) -> int:
         """
         获取指定 app_id 的通知等级
+        -1: 仅错误
         0: 关闭
         1: 仅应用
         2: 全部（应用和节点，逐条发送）

--- a/src/one_dragon/base/config/notify_config.py
+++ b/src/one_dragon/base/config/notify_config.py
@@ -2,6 +2,7 @@ from one_dragon.base.config.yaml_config import YamlConfig
 
 
 class NotifyLevel:
+    ONLY_ERROR = -1
     OFF = 0
     APP = 1
     ALL = 2

--- a/src/one_dragon/base/operation/operation_notify.py
+++ b/src/one_dragon/base/operation/operation_notify.py
@@ -217,9 +217,8 @@ def send_node_notify(
     pool = operation.ctx.run_context.notify_pool
     notify_level = _get_notify_level(operation)
     current_fail = round_result.is_fail
-    notify_on_error = operation.ctx.notify_config.notify_on_error
 
-    should_collect_notify = (notify_on_error and current_fail) or (notify_level >= NotifyLevel.APP)
+    should_collect_notify = (notify_level == NotifyLevel.ONLY_ERROR and current_fail) or (notify_level >= NotifyLevel.APP)
 
     if not should_collect_notify or current_node is None:
         return
@@ -298,7 +297,7 @@ def send_node_notify(
     pool.add(content=message, image=image)
 
     should_send_all_nodes = notify_level == NotifyLevel.ALL
-    should_send_fail_notify = current_fail and notify_on_error
+    should_send_fail_notify = current_fail and (operation.ctx.notify_config.notify_on_error or notify_level == NotifyLevel.ONLY_ERROR)
     should_send_now = should_send_all_nodes or should_send_fail_notify
 
     if should_send_now:

--- a/src/one_dragon/base/operation/operation_notify.py
+++ b/src/one_dragon/base/operation/operation_notify.py
@@ -219,7 +219,7 @@ def send_node_notify(
     current_fail = round_result.is_fail
     notify_on_error = operation.ctx.notify_config.notify_on_error
 
-    should_collect_notify = notify_level >= NotifyLevel.APP
+    should_collect_notify = (notify_on_error and current_fail) or (notify_level >= NotifyLevel.APP)
 
     if not should_collect_notify or current_node is None:
         return

--- a/src/one_dragon_qt/widgets/notify_dialog.py
+++ b/src/one_dragon_qt/widgets/notify_dialog.py
@@ -69,6 +69,7 @@ class NotifyDialog(MessageBoxBase):
             label = BodyLabel(gt(app_name), self)
             combo = ComboBox(self)
             combo.addItem(gt('关闭'), userData=NotifyLevel.OFF)
+            combo.addItem(gt('仅错误'), userData=NotifyLevel.ONLY_ERROR)
             combo.addItem(gt('仅应用'), userData=NotifyLevel.APP)
             combo.addItem(gt('全部（逐条）'), userData=NotifyLevel.ALL)
             combo.addItem(gt('全部（合并）'), userData=NotifyLevel.MERGE)

--- a/src/one_dragon_qt/widgets/notify_dialog.py
+++ b/src/one_dragon_qt/widgets/notify_dialog.py
@@ -38,9 +38,9 @@ class NotifyDialog(MessageBoxBase):
 
         self.notify_on_error_switch = SwitchButton(self)
         self.notify_on_error_switch.setChecked(self.ctx.notify_config.notify_on_error)
-        self.notify_on_error_switch._onText = gt('节点失败立即通知')
-        self.notify_on_error_switch._offText = gt('节点失败立即通知')
-        self.notify_on_error_switch.label.setText(gt('节点失败立即通知'))
+        self.notify_on_error_switch._onText = gt('(全部-合并开启时)节点失败立即通知')
+        self.notify_on_error_switch._offText = gt('(全部-合并开启时)节点失败立即通知')
+        self.notify_on_error_switch.label.setText(gt('(全部-合并开启时)节点失败立即通知'))
         self.viewLayout.addWidget(HorizontalSettingCardGroup([self.before_notify_switch, self.notify_on_error_switch], spacing=6))
 
         # 存储所有应用的 ComboBox

--- a/src/one_dragon_qt/widgets/notify_dialog.py
+++ b/src/one_dragon_qt/widgets/notify_dialog.py
@@ -69,7 +69,7 @@ class NotifyDialog(MessageBoxBase):
             label = BodyLabel(gt(app_name), self)
             combo = ComboBox(self)
             combo.addItem(gt('关闭'), userData=NotifyLevel.OFF)
-            combo.addItem(gt('仅错误'), userData=NotifyLevel.ONLY_ERROR)
+            combo.addItem(gt('仅错误时'), userData=NotifyLevel.ONLY_ERROR)
             combo.addItem(gt('仅应用'), userData=NotifyLevel.APP)
             combo.addItem(gt('全部（逐条）'), userData=NotifyLevel.ALL)
             combo.addItem(gt('全部（合并）'), userData=NotifyLevel.MERGE)


### PR DESCRIPTION
我就说我今天盘子满了怎么没提示呢

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 新增“仅错误”通知等级，可为单个应用配置仅在发生错误时触发即时通知。
  * 通知设置界面文案与级别选项调整，更清晰显示“全部/合并”情形下的立即通知含义。

* **Bug Fixes**
  * 优化节点失败的收集与立即推送判定：在“仅错误”或启用立即通知时，失败将按预期触发即时或合并/逐条处理。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneDragon-Anything/ZenlessZoneZero-OneDragon/pull/2261)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->