### PR TITLE
fix: 未配置账号密码时跳过强制退出登录

### DIFF
--- a/src/zzz_od/operation/enter_game/enter_game.py
+++ b/src/zzz_od/operation/enter_game/enter_game.py
@@ -34,6 +34,11 @@ class EnterGame(ZOperation):
         if switch:
             self.force_login = True
 
+        # 未配置账号密码时，无法主动切换账号，依赖游戏保存的登录状态直接进入
+        cfg = self.ctx.game_account_config
+        if not cfg.account and not cfg.password and not cfg.bilibili_account_name:
+            self.force_login = False
+
         self.already_login: bool = False  # 是否已经登录了
         self.use_clipboard: bool = self.ctx.game_config.type_input_way == TypeInputWay.CLIPBOARD.value.value  # 使用剪切板输入
 


### PR DESCRIPTION
## 问题

多账号一条龙中，启用「全部实例」模式且实例数 > 1 时，\orce_login\ 固定为 \True\，每次进入游戏前都会强制点击「切换账号」退出当前登录，再用存储的账号密码重新登录。

**这在以下场景中是不必要且有害的：**

国服与国际服账号各只有一个，游戏本身会保存上次登录的账号状态，切换服务器后重新打开游戏会自动登录，无需退出重登。而反复触发退出登录操作，**在国际服会触发人机验证（验证码），导致自动化流程中断无法继续**。

## 根本原因

\EnterGame.__init__()\ 中 \orce_login\ 的判断逻辑只检查了实例数量，没有区分：
- 同服多账号：需要退出当前账号并用存储的密码重登 ✅
- 未配置账号密码：依赖游戏自动保存的登录状态直接进入，无需退出重登 ❌（当前会错误地强制退出）

## 修复方案

在 \orce_login\ 判断之后增加一条覆盖规则：若当前实例的账号、密码、B服用户名均未配置，则将 \orce_login\ 置为 \False\，直接利用游戏保存的登录状态进入游戏。

**不影响已配置账号密码的用户**，其行为与修复前完全一致。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **功能改进**
  * 优化了登录流程，当未配置账号和密码时，游戏将自动使用已保存的登录状态进行登录，无需手动干预。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneDragon-Anything/ZenlessZoneZero-OneDragon/pull/2272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->